### PR TITLE
Fix license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "Environment :: Console",
         "Framework :: Jupyter",
         "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
The license changed from MIT to BSD in 5e8a7d7c85005bc4992ba95b0756cccff249189a but this one string was missed.