### PR TITLE
Add ensembl plants to search

### DIFF
--- a/gget/gget_search.py
+++ b/gget/gget_search.py
@@ -22,6 +22,7 @@ import pandas as pd
 # Custom functions
 from .utils import gget_species_options, find_latest_ens_rel, wrap_cols_func
 
+from .constants import ENSEMBL_FTP_URL, ENSEMBL_FTP_URL_PLANT
 
 def search(
     searchwords,
@@ -103,8 +104,16 @@ def search(
     # In case species was passed with upper case letters
     species = species.lower()
 
-    # Fetch all available databases
-    databases = gget_species_options()
+    # Fetch ensembl databases
+    databases = gget_species_options(
+        database=ENSEMBL_FTP_URL, release=None
+    )
+
+    # Add ensembl plant databases
+    databases += gget_species_options(
+        database=ENSEMBL_FTP_URL_PLANT, release=None
+    )
+
     db = []
     for datab in databases:
         if species in datab:
@@ -141,17 +150,17 @@ def search(
     ## Connect to data base
     try:
         db_connection = sql.connect(
-            host="ensembldb.ensembl.org", database=db, user="anonymous", password=""
+            host="mysql-eg-publicsql.ebi.ac.uk", database=db, user="anonymous", password=""
         )
     except:
         try:
             # Try different port
             db_connection = sql.connect(
-                host="ensembldb.ensembl.org",
+                host="mysql-eg-publicsql.ebi.ac.uk",
                 database=db,
                 user="anonymous",
                 password="",
-                port=5306,
+                port=4157,
             )
 
         except Exception as e:

--- a/gget/utils.py
+++ b/gget/utils.py
@@ -580,7 +580,7 @@ def find_latest_ens_rel(database=ENSEMBL_FTP_URL):
     return ENS_rel
 
 
-def gget_species_options(release=None):
+def gget_species_options(database=ENSEMBL_FTP_URL, release=None):
     """
     Function to find all available species core databases for gget.
 
@@ -591,7 +591,7 @@ def gget_species_options(release=None):
     Returns list of available core databases.
     """
     # Find latest Ensembl release
-    ENS_rel = find_latest_ens_rel()
+    ENS_rel = find_latest_ens_rel(database)
 
     # If release != None, use user-defined Ensembl release
     if release != None:
@@ -604,7 +604,7 @@ def gget_species_options(release=None):
             ENS_rel = release
 
     # Find all available databases
-    url = ENSEMBL_FTP_URL + f"release-{ENS_rel}/mysql/"
+    url = database + f"release-{ENS_rel}/mysql/"
     html = requests.get(url)
 
     # Raise error if status code not "OK" Response


### PR DESCRIPTION
This PR adds the ability to search the ensembl plants database.

Main changes:

- switch database server to the EBI one, which includes all organisms
- add a database argument to the `gget_species_options` function

The resulting ensemble IDs are retrievable with e.g. `seq`, so no changes to other subcommands appear to be needed.

