### PR TITLE
Feature proposal: KEGG PATHWAY image generation

### DIFF
--- a/docs/src/enrichr.md
+++ b/docs/src/enrichr.md
@@ -28,6 +28,12 @@ Alternatively: use flag `--ensembl_background` to input a list of Ensembl gene I
 Path to the file the results will be saved in, e.g. path/to/directory/results.csv (or .json). Default: Standard out.   
 Python: `save=True` will save the output in the current working directory.
 
+`-k` `--kegg`
+Path to the png file the marked KEGG pathway images will be saved in, e.g. path/to/directory/pathway.png.
+
+`-r` `--kegg_rank`
+Rank of the KEGG pathway to be plotted.
+
 `figsize`  
 Python only. (width, height) of plot in inches. (Default: (10,10))
 

--- a/gget/gget_enrichr.py
+++ b/gget/gget_enrichr.py
@@ -170,7 +170,6 @@ def enrichr(
         if verbose:
             logging.info(f"Performing Enichr analysis using database {database}.")
 
-
     # Check if KEGG database
     if kegg is not None:
         if not database.startswith("KEGG"):
@@ -466,16 +465,20 @@ def enrichr(
                 bbox_inches="tight",
                 transparent=True,
             )
-            
+
     if kegg is not None:
         try:
             import pykegg
         except ImportError:
             logging.error("Please install `pykegg` for plotting")
             return
-        candidate_rank = df[df["rank"]==kegg_rank].iloc[0,:]
-        kegg_img = pykegg.visualize(candidate_rank["path_name"],
-            candidate_rank["overlapping_genes"], db=database, output=kegg)
+        candidate_rank = df[df["rank"] == kegg_rank].iloc[0, :]
+        kegg_img = pykegg.visualize(
+            candidate_rank["path_name"],
+            candidate_rank["overlapping_genes"],
+            db=database,
+            output=kegg,
+        )
 
     if json:
         results_dict = json_package.loads(df.to_json(orient="records"))

--- a/gget/main.py
+++ b/gget/main.py
@@ -2007,6 +2007,8 @@ def main():
             ensembl_bkg=args.ensembl_bkg,
             json=args.csv,
             verbose=args.quiet,
+            kegg=args.kegg,
+            kegg_rank=args.kegg_rank,
         )
 
         # Check if the function returned something

--- a/gget/main.py
+++ b/gget/main.py
@@ -835,16 +835,14 @@ def main():
         required=False,
         help=(
             "Path to the png file the marked KEGG pathway images will be saved in, e.g. path/to/directory/pathway.png."
-        )
+        ),
     )
     parser_enrichr.add_argument(
         "-r",
         "--kegg_rank",
         type=int,
         required=False,
-        help=(
-            "Rank of the KEGG pathway to be plotted."
-        )
+        help=("Rank of the KEGG pathway to be plotted."),
     )
 
     ## gget archs4 subparser

--- a/gget/main.py
+++ b/gget/main.py
@@ -828,6 +828,24 @@ def main():
         required=False,
         help="DEPRECATED - json is now the default output format (convert to csv using flag [--csv]).",
     )
+    parser_enrichr.add_argument(
+        "-k",
+        "--kegg",
+        type=str,
+        required=False,
+        help=(
+            "Path to the png file the marked KEGG pathway images will be saved in, e.g. path/to/directory/pathway.png."
+        )
+    )
+    parser_enrichr.add_argument(
+        "-r",
+        "--kegg_rank",
+        type=int,
+        required=False,
+        help=(
+            "Rank of the KEGG pathway to be plotted."
+        )
+    )
 
     ## gget archs4 subparser
     archs4_desc = "Find the most correlated genes or the tissue expression atlas of a gene using data from the human and mouse RNA-seq database ARCHS4 (https://maayanlab.cloud/archs4/)."


### PR DESCRIPTION
Hello.
Thank you very much for developing this useful software.

I would like to propose a feature in `gget enrichr` that produces a KEGG PATHWAY image with the genes from the enrichment analysis highlighted.

Example usage:

`gget enrichr -db pathway --kegg out.png --kegg_rank 1 DDX41 IRF3`

will output an image (`out.png`) with IRF3 highlighted in the rank 1 pathway.
The feature uses the library pykegg. It checks if the package is installed and raises an error if not.

I would be grateful if you could review the PR.