### PR TITLE
cbio: fix support for pre-2.1.0 pandas

### DIFF
--- a/gget/gget_cbio.py
+++ b/gget/gget_cbio.py
@@ -25,6 +25,11 @@ _V = TypeVar("_V")
 logger = set_up_logger()
 
 
+if not hasattr(pd.DataFrame, "map"):
+    logger.info("Old pandas version detected. Patching DataFrame.map to DataFrame.applymap")
+    pd.DataFrame.map = pd.DataFrame.applymap
+
+
 def _ints_between(
     start: int, end: int, max_count: int, min_count: int, verbose: bool = False
 ) -> list[int]:

--- a/gget/gget_cbio.py
+++ b/gget/gget_cbio.py
@@ -208,6 +208,7 @@ def download_cbioportal_data(
 
     for study_id in study_ids:
         file_types = ["mutations", "cna", "sv", "clinical_patient", "clinical_sample"]
+        optional_file_types = ["cna", "sv"]
 
         for file_type in file_types:
             try:
@@ -231,7 +232,8 @@ def download_cbioportal_data(
                     logger.error(
                         f"Failed to download {file_type} data for study {study_id}"
                     )
-                    success = False
+                    if file_type not in optional_file_types:
+                        success = False
                     continue
 
                 lines = response.content.decode().splitlines(keepends=True)

--- a/gget/gget_cbio.py
+++ b/gget/gget_cbio.py
@@ -553,14 +553,14 @@ class _GeneAnalysis:
             aggregation_dict = {
                 "Hugo_Symbol": lambda x: ",".join(x.unique()),
                 "Entrez_Gene_Id": lambda x: ",".join(map(str, x.unique())),
-                "Consequence": lambda x: ",".join(x.unique()),
+                "Consequence": lambda x: ",".join(map(str, x.unique())),
             }
         elif self.merge_type == _SYMBOL:
             self.column_for_merging = "Hugo_Symbol"
 
             aggregation_dict = {
                 "Entrez_Gene_Id": lambda x: ",".join(map(str, x.unique())),
-                "Consequence": lambda x: ",".join(x.unique()),
+                "Consequence": lambda x: ",".join(map(str, x.unique())),
             }
         else:
             raise AssertionError(f"Invalid merge type: {self.merge_type}")

--- a/gget/gget_cbio.py
+++ b/gget/gget_cbio.py
@@ -544,6 +544,12 @@ class _GeneAnalysis:
                     "No Ensembl gene IDs found in the mutation data. Merging on gene symbol instead."
                 )
 
+        def join_unique_string_values(series):
+            if series.isnull().all():
+                return np.nan
+            else:
+                return ','.join(series.dropna().unique())
+
         if self.merge_type == _ENSEMBL:
             self.column_for_merging = "Ensembl_Gene_ID"
 
@@ -553,14 +559,14 @@ class _GeneAnalysis:
             aggregation_dict = {
                 "Hugo_Symbol": lambda x: ",".join(x.unique()),
                 "Entrez_Gene_Id": lambda x: ",".join(map(str, x.unique())),
-                "Consequence": lambda x: ",".join(map(str, x.unique())),
+                "Consequence": join_unique_string_values,
             }
         elif self.merge_type == _SYMBOL:
             self.column_for_merging = "Hugo_Symbol"
 
             aggregation_dict = {
                 "Entrez_Gene_Id": lambda x: ",".join(map(str, x.unique())),
-                "Consequence": lambda x: ",".join(map(str, x.unique())),
+                "Consequence": join_unique_string_values,
             }
         else:
             raise AssertionError(f"Invalid merge type: {self.merge_type}")


### PR DESCRIPTION
Fix support for pre-2.1.0 pandas by automatically aliasing `pd.DataFrame.map` to be `pd.DataFrame.applymap` when `pd.DataFrame.map` is not found

Also allows plotting even for studies that do not contain `cna` or `sv` data