### PR TITLE
requirements.txt: Allow using newer mysql-connector versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pandas>=1.0.0
 requests>=2.22.0
 ipython
 matplotlib
-mysql-connector-python>=8.0.5,<=8.0.29
+mysql-connector-python>=8.0.32
 beautifulsoup4>=4.10.0
 ipywidgets
 tqdm


### PR DESCRIPTION
The bug causing https://github.com/pachterlab/gget/issues/31 was fixed in version 8.0.32: https://github.com/mysql/mysql-connector-python/blob/8.0.32/CHANGES.txt#L23

I haven't actually tested this (I have to package this first in order to have it working at all due to the linux distro I use); I'll get back if/when I do.