### PR TITLE
Fix gene handling in cellxgene

### DIFF
--- a/gget/gget_cellxgene.py
+++ b/gget/gget_cellxgene.py
@@ -159,6 +159,17 @@ def cellxgene(
     # Convert all arguments to list
     args = convert_to_list(args)
 
+    # Ensure gene argument is a list and formatted correctly
+    if gene:
+        if isinstance(gene, str):
+            gene = [gene]
+        # Format gene names to match species conventions when not using Ensembl IDs
+        if not ensembl:
+            if species == "homo_sapiens":
+                gene = [g.upper() for g in gene]
+            elif species == "mus_musculus":
+                gene = [g.capitalize() for g in gene]
+
     # Define metadata filter
     if is_primary_data:
         obs_value_filter = f"is_primary_data == True"

--- a/tests/test_cellxgene.py
+++ b/tests/test_cellxgene.py
@@ -1,6 +1,9 @@
 import unittest
 import pandas as pd
 import json
+import importlib.util
+import sys
+import types
 from gget.gget_cellxgene import cellxgene
 
 # Load dictionary containing arguments and expected results
@@ -35,6 +38,10 @@ def repr_dict(adata):
     return d
 
 
+cellxgene_census_spec = importlib.util.find_spec("cellxgene_census")
+
+
+@unittest.skipUnless(cellxgene_census_spec, "cellxgene_census not installed")
 class TestCellxgene(unittest.TestCase):
     def test_cellxgene_adata(self):
         test = "test1"
@@ -55,3 +62,38 @@ class TestCellxgene(unittest.TestCase):
         result_to_test = result_to_test.values.tolist()[:25]
 
         self.assertListEqual(result_to_test, expected_result)
+
+
+class TestCellxgeneGeneInput(unittest.TestCase):
+    def setUp(self):
+        class DummyCtx:
+            def __enter__(self):
+                return None
+
+            def __exit__(self, exc_type, exc, tb):
+                pass
+
+        def open_soma(*args, **kwargs):
+            return DummyCtx()
+
+        def get_anndata(*, census, organism, var_value_filter, obs_value_filter, column_names):
+            return {"var_value_filter": var_value_filter}
+
+        self._orig = sys.modules.get("cellxgene_census")
+        sys.modules["cellxgene_census"] = types.SimpleNamespace(
+            open_soma=open_soma, get_anndata=get_anndata
+        )
+
+    def tearDown(self):
+        if self._orig is not None:
+            sys.modules["cellxgene_census"] = self._orig
+        else:
+            del sys.modules["cellxgene_census"]
+
+    def test_gene_as_string_human(self):
+        result = cellxgene(gene="ACE2")
+        self.assertEqual(result["var_value_filter"], "feature_name in ['ACE2']")
+
+    def test_gene_as_string_mouse(self):
+        result = cellxgene(gene="PAX7", species="mus_musculus")
+        self.assertEqual(result["var_value_filter"], "feature_name in ['Pax7']")


### PR DESCRIPTION
## Summary
- normalize gene inputs for `cellxgene`, converting strings to lists and applying species-specific casing
- add tests covering string gene inputs and skip live tests when `cellxgene_census` is unavailable

## Testing
- `pytest tests/test_cellxgene.py::TestCellxgeneGeneInput -q`
- `pytest -q` *(fails: No module named 'parameterized')*


------
https://chatgpt.com/codex/tasks/task_b_68c0ab45ee648332835d43a2a344bbe8