### PR TITLE
feat(pdb): support PDBx/mmCIF format with automatic fallback (#178, #177)

### DIFF
--- a/.github/badges/tests.json
+++ b/.github/badges/tests.json
@@ -1,1 +1,6 @@
-{"schemaVersion": 1, "label": "tests", "message": "394/400 passing", "color": "yellow"}
+{
+	"schemaVersion": 1,
+	"label": "tests",
+	"message": "394/400 passing",
+	"color": "yellow"
+}

--- a/docs/src/en/pdb.md
+++ b/docs/src/en/pdb.md
@@ -3,7 +3,7 @@
 > Python arguments are equivalent to long-option arguments (`--arg`), unless otherwise specified. Flags are True/False arguments in Python. The manual for any gget tool can be called from the command-line using the `-h` `--help` flag.  
 # gget pdb 🔮
 Query [RCSB Protein Data Bank (PDB)](https://www.rcsb.org/) for the protein structure/metadata of a given PDB ID.  
-Return format: Resource 'pdb' is returned in PDB format. All other resources are returned in JSON format.  
+Return format: Resource 'pdb' is returned in legacy PDB format (or PDBx/mmCIF if the legacy PDB file is unavailable), 'mmcif' in PDBx/mmCIF format. All other resources are returned in JSON format.  
 
 **Positional argument**  
 `pdb_id`  
@@ -12,7 +12,8 @@ PDB ID to be queried, e.g. '7S7U'.
 **Optional arguments**  
  `-r` `--resource`  
  Defines type of information to be returned. One of the following:  
- 'pdb': Returns the protein structure in PDB format (default).  
+ 'pdb': Returns the protein structure in legacy PDB format (default). The legacy PDB format is being phased out by RCSB and is unavailable for large structures; in that case gget automatically falls back to the PDBx/mmCIF format.  
+ 'mmcif': Returns the protein structure in PDBx/mmCIF format (.cif).  
  'entry': Information about PDB structures at the top level of PDB structure hierarchical data organization.  
  'pubmed': Get PubMed annotations (data integrated from PubMed) for a given entry's primary citation.  
  'assembly': Information about PDB structures at the quaternary structure level.  
@@ -41,6 +42,17 @@ gget pdb 7S7U -o 7S7U.pdb
 gget.pdb("7S7U", save=True)
 ```
 &rarr; Saves the structure of 7S7U in PDB format as '7S7U.pdb' in the current working directory.
+
+**Fetch a structure in PDBx/mmCIF format (recommended for large structures, which have no legacy PDB file):**  
+```bash
+gget pdb 6Q38 -r mmcif -o 6Q38.cif
+```
+```python
+# Python
+gget.pdb("6Q38", resource="mmcif", save=True)
+```
+&rarr; Saves the structure of 6Q38 in PDBx/mmCIF format as '6Q38.cif' in the current working directory.  
+Note: `gget pdb 6Q38` (without `-r mmcif`) also works — since 6Q38 has no legacy PDB file, gget automatically falls back to PDBx/mmCIF and saves a '.cif' file.
 
 **Find PDB crystal structures for a comparative analysis of protein structure:**  
 ```bash

--- a/docs/src/en/updates.md
+++ b/docs/src/en/updates.md
@@ -5,6 +5,9 @@
 #### *gget* officially became part of *scverse* on June 9, 2026. 🥳🥳🥳
 
 **Version ≥ 0.30.8** (XXX XX, 2026):  
+- [`gget pdb`](pdb.md): Added support for the PDBx/mmCIF structure format (fixes [issue 178](https://github.com/scverse/gget/issues/178) and [issue 177](https://github.com/scverse/gget/issues/177)).
+  - New `resource="mmcif"` option downloads the structure in PDBx/mmCIF format (`.cif`).
+  - The default `resource="pdb"` now automatically falls back to PDBx/mmCIF when the legacy PDB file is unavailable (e.g. for large structures), since the legacy PDB format is being phased out by RCSB. A warning is logged and saved files use the correct extension (`.cif`).
 
 
 **Version ≥ 0.30.7** (Jun 21, 2026):  

--- a/gget/gget_cbio.py
+++ b/gget/gget_cbio.py
@@ -415,7 +415,9 @@ def _get_ensembl_gene_name_bulk(gene_ids: list[str]) -> dict[str, Any]:
         raise e
 
 
-def _get_valid_ensembl_gene_id(row: pd.Series, transcript_column: str = "seq_ID", gene_column: str = "gene_name") -> Any:
+def _get_valid_ensembl_gene_id(
+    row: pd.Series, transcript_column: str = "seq_ID", gene_column: str = "gene_name"
+) -> Any:
     ensembl_gene_id = _get_ensembl_gene_id(row[transcript_column])
     if ensembl_gene_id == "Unknown":
         return row[gene_column]

--- a/gget/gget_g2p.py
+++ b/gget/gget_g2p.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import io
+
 import pandas as pd
 import requests
 
 from .constants import G2P_API
-from .utils import set_up_logger, DEFAULT_REQUESTS_TIMEOUT
+from .utils import DEFAULT_REQUESTS_TIMEOUT, set_up_logger
 
 logger = set_up_logger()
 
@@ -43,9 +44,7 @@ def g2p(
     """
     resources = ["features", "map", "alignment"]
     if resource not in resources:
-        raise ValueError(
-            f"'resource' argument specified as {resource}. Expected one of: {', '.join(resources)}"
-        )
+        raise ValueError(f"'resource' argument specified as {resource}. Expected one of: {', '.join(resources)}")
 
     if not uniprot_id:
         raise ValueError(
@@ -69,9 +68,7 @@ def g2p(
         url = f"{base}/{isoform}/alignment"
 
     if verbose:
-        logger.info(
-            f"Querying the Genomics 2 Proteins portal ('{resource}') for {gene} / {uniprot_id}..."
-        )
+        logger.info(f"Querying the Genomics 2 Proteins portal ('{resource}') for {gene} / {uniprot_id}...")
 
     try:
         r = requests.get(
@@ -92,9 +89,7 @@ def g2p(
         return
 
     if not r.text.strip():
-        logger.warning(
-            "The Genomics 2 Proteins portal returned an empty result for this query."
-        )
+        logger.warning("The Genomics 2 Proteins portal returned an empty result for this query.")
         return pd.DataFrame()
 
     df = pd.read_csv(io.StringIO(r.text), sep="\t")

--- a/gget/gget_g2p.py
+++ b/gget/gget_g2p.py
@@ -19,9 +19,9 @@ def g2p(
     save: bool = False,
     verbose: bool = True,
 ) -> pd.DataFrame | None:
-    """
-    Query the Genomics 2 Proteins (G2P) portal (https://g2p.broadinstitute.org/) to link
-    genes/proteins to per-residue structural and functional annotations.
+    """Query the Genomics 2 Proteins (G2P) portal to link genes/proteins to per-residue structural and functional annotations.
+
+    Portal: https://g2p.broadinstitute.org/
 
     Args:
     - gene          Gene symbol, e.g. "BRCA1" (str).

--- a/gget/gget_muscle.py
+++ b/gget/gget_muscle.py
@@ -113,9 +113,7 @@ def muscle(fasta: str | list[str], super5: bool = False, out: str | None = None,
         diagnosis = diagnose_binary_load_error(stderr_2, "muscle")
         if diagnosis:
             raise RuntimeError(diagnosis)
-        raise RuntimeError(
-            f"MUSCLE failed with exit code {process_2.returncode}. See stderr above for details."
-        )
+        raise RuntimeError(f"MUSCLE failed with exit code {process_2.returncode}. See stderr above for details.")
     if verbose:
         logger.info(f"MUSCLE alignment complete. Alignment time: {round(time.time() - start_time, 2)} seconds")
 

--- a/gget/gget_pdb.py
+++ b/gget/gget_pdb.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import Any
-
 import json
+from typing import Any
 from urllib.error import HTTPError
 from urllib.request import urlopen
 

--- a/gget/gget_pdb.py
+++ b/gget/gget_pdb.py
@@ -19,7 +19,11 @@ def pdb(pdb_id: str, resource: str = "pdb", identifier: str | int | None = None,
     Args:
     - pdb_id        PDB ID to be queried (str), e.g. "7S7U".
     - resource      Defines type of information to be returned.
-                    "pdb": Returns the protein structure in PDB format (default).
+                    "pdb": Returns the protein structure in legacy PDB format (default).
+                           Note: the legacy PDB format is being phased out by RCSB and is
+                           not available for large structures. When the legacy PDB file does
+                           not exist, gget automatically falls back to the PDBx/mmCIF format.
+                    "mmcif": Returns the protein structure in PDBx/mmCIF format (.cif).
                     "entry": Information about PDB structures at the top level of PDB structure hierarchical data organization.
                     "pubmed": Get PubMed annotations (data integrated from PubMed) for a given entry's primary citation.
                     "assembly": Information about PDB structures at the quaternary structure level.
@@ -34,11 +38,16 @@ def pdb(pdb_id: str, resource: str = "pdb", identifier: str | int | None = None,
                     Assembly/entity IDs are numbers (e.g. 1), and chain IDs are letters (e.g. "A").
     - save          True/False wether to save JSON/PDB with query results in the current working directory (default: False).
 
-    Returns requested information in JSON format (except for resource="pdb" which returns protein structure in PDB format).
+    Returns requested information in JSON format (except for resource="pdb"/"mmcif" which
+    return the protein structure in PDB/PDBx-mmCIF format).
     """
+    # Resources that download a structure file (text), not JSON
+    structure_resources = ["pdb", "mmcif"]
+
     # Check if resource argument is valid
     resources = [
         "pdb",
+        "mmcif",
         "entry",
         "pubmed",
         "assembly",
@@ -74,26 +83,34 @@ def pdb(pdb_id: str, resource: str = "pdb", identifier: str | int | None = None,
     if resource in need_chain_id and identifier is None:
         raise ValueError("Please define chain ID (e.g. 'A') as 'identifier'.")
 
-    # Define URLs for HTTP request
-    if resource != "pdb":
-        # URLs to request resources other than PDB file
+    # Define URLs for HTTP request.
+    # Each entry is (url, fetched_format) so we can track which structure format
+    # was actually returned ("pdb"/"mmcif"/None for JSON resources).
+    if resource not in structure_resources:
+        # URLs to request resources other than a structure file
         if identifier is not None:
             url = f"{RCSB_PDB_API}{resource}/{pdb_id}/{identifier}"
         else:
             url = f"{RCSB_PDB_API}{resource}/{pdb_id}"
 
-        urls = [url]  # only one option for JSON resources
+        urls = [(url, None)]  # only one option for JSON resources
+    elif resource == "mmcif":
+        # PDBx/mmCIF file
+        urls = [(f"https://files.rcsb.org/download/{pdb_id}.cif", "mmcif")]
     else:
-        # Try wwPDB first, then RCSB as fallback
+        # Legacy PDB format: try wwPDB first, then RCSB, then automatically
+        # fall back to PDBx/mmCIF (legacy PDB is unavailable for large structures).
         urls = [
-            f"https://files.wwpdb.org/download/{pdb_id}.pdb",
-            f"https://files.rcsb.org/download/{pdb_id}.pdb",
+            (f"https://files.wwpdb.org/download/{pdb_id}.pdb", "pdb"),
+            (f"https://files.rcsb.org/download/{pdb_id}.pdb", "pdb"),
+            (f"https://files.rcsb.org/download/{pdb_id}.cif", "mmcif"),
         ]
 
     # Submit URL request with fallback logic
     r = None
     code = None
-    for url in urls:
+    fetched_format = None
+    for url, fmt in urls:
         try:
             r = urlopen(url)
 
@@ -103,6 +120,7 @@ def pdb(pdb_id: str, resource: str = "pdb", identifier: str | int | None = None,
                 code = r.getcode()
 
             if code == 200:
+                fetched_format = fmt
                 break
         except HTTPError:
             continue
@@ -124,7 +142,7 @@ def pdb(pdb_id: str, resource: str = "pdb", identifier: str | int | None = None,
             logger.error(f"{resource} for {pdb_id} was not found. Please double-check arguments and try again.")
         return
 
-    if resource != "pdb":
+    if resource not in structure_resources:
         # Read json formatted results
         results = json.load(r)
 
@@ -133,11 +151,19 @@ def pdb(pdb_id: str, resource: str = "pdb", identifier: str | int | None = None,
         if ids is not None:
             ids.sort()
     else:
-        # Read PDB file
+        # Read structure file (PDB or PDBx/mmCIF)
         results = r.read().decode()
 
+        # Inform the user if a legacy PDB request was served as mmCIF instead
+        if resource == "pdb" and fetched_format == "mmcif":
+            logger.warning(
+                f"The legacy PDB format is not available for {pdb_id} (it is being phased out "
+                f"by RCSB). Returning the PDBx/mmCIF format instead. "
+                f"Use resource='mmcif' to request it directly and silence this warning."
+            )
+
     if save:
-        if resource != "pdb":
+        if resource not in structure_resources:
             # Save the results in json format
             if identifier is not None:
                 out_name = f"{pdb_id}_{identifier}_{resource}.json"
@@ -148,8 +174,9 @@ def pdb(pdb_id: str, resource: str = "pdb", identifier: str | int | None = None,
                 json.dump(results, f, ensure_ascii=False, indent=4)
 
         else:
-            # Save the PDB file
-            with open(f"{pdb_id}.pdb", "w") as f:
+            # Save the structure file using the extension of the format actually fetched
+            extension = "cif" if fetched_format == "mmcif" else "pdb"
+            with open(f"{pdb_id}.{extension}", "w") as f:
                 f.write(results)
 
     return results

--- a/gget/gget_search.py
+++ b/gget/gget_search.py
@@ -310,8 +310,7 @@ def search(
     # inside the list to None so an empty-synonym row is [None] rather than
     # [nan]. (SQL LEFT JOIN on external_synonym surfaces missing rows as NaN.)
     df["synonym"] = [
-        [None if pd.isna(item) else item
-         for item in np.sort(syn if isinstance(syn, list) else [syn]).tolist()]
+        [None if pd.isna(item) else item for item in np.sort(syn if isinstance(syn, list) else [syn]).tolist()]
         for syn in df["synonym"].values
     ]
 

--- a/gget/gget_setup.py
+++ b/gget/gget_setup.py
@@ -115,9 +115,7 @@ def setup(module: str, verbose: bool = True, out: str | None = None) -> None:
         raise ValueError(f"'module' argument specified as {module}. Expected one of: {', '.join(supported_modules)}")
 
     if module == "gpt":
-        logger.warning(
-            "gget gpt is no longer actively maintained."
-        )
+        logger.warning("gget gpt is no longer actively maintained.")
         _install("openai<=0.28.1", "openai", verbose=verbose)
 
     elif module == "cellxgene":

--- a/gget/gget_virus.py
+++ b/gget/gget_virus.py
@@ -341,7 +341,10 @@ def _retry_with_exponential_backoff(
     initial_delay: float = API_INITIAL_RETRY_DELAY,
     backoff_multiplier: float = API_RETRY_BACKOFF_MULTIPLIER,
     max_delay: int = MAX_RETRY_DELAY,
-    retryable_exceptions: tuple[type[BaseException], ...] = (requests.exceptions.ConnectionError, requests.exceptions.HTTPError),
+    retryable_exceptions: tuple[type[BaseException], ...] = (
+        requests.exceptions.ConnectionError,
+        requests.exceptions.HTTPError,
+    ),
     failed_commands: dict[str, Any] | None = None,
 ) -> tuple[bool, Any, dict[str, Any] | None]:
     """Execute an operation with exponential backoff retry logic.
@@ -414,7 +417,9 @@ def _retry_with_exponential_backoff(
     return False, None, error_info
 
 
-def _track_failed_operation(failed_commands: dict[str, Any] | None, operation_type: str, batch_info: dict[str, Any], error_info: dict[str, Any]) -> None:
+def _track_failed_operation(
+    failed_commands: dict[str, Any] | None, operation_type: str, batch_info: dict[str, Any], error_info: dict[str, Any]
+) -> None:
     """Track a failed operation in the failed_commands dictionary.
 
     This ensures consistent error tracking across all operation types for
@@ -864,7 +869,9 @@ def _parse_baseline_file(baseline_path: str) -> set[str]:
     return baseline_accessions
 
 
-def _deduplicate_metadata_against_baseline(metadata_dict: dict[str, Any], baseline_accessions: set[str]) -> tuple[dict[str, Any], int]:
+def _deduplicate_metadata_against_baseline(
+    metadata_dict: dict[str, Any], baseline_accessions: set[str]
+) -> tuple[dict[str, Any], int]:
     """Remove metadata records whose accessions are already in the baseline set.
 
     Args:
@@ -889,7 +896,9 @@ def _deduplicate_metadata_against_baseline(metadata_dict: dict[str, Any], baseli
     return new_metadata, skipped_count
 
 
-def _save_partial_metadata(metadata_dict: dict[str, Any], outfolder: str, virus_clean: str, reason: str = "api_failure") -> str | None:
+def _save_partial_metadata(
+    metadata_dict: dict[str, Any], outfolder: str, virus_clean: str, reason: str = "api_failure"
+) -> str | None:
     """Save partial metadata to CSV for recovery via --baseline.
 
     Args:
@@ -2786,7 +2795,9 @@ def process_cached_download(zip_file: str, virus_type: str = "virus") -> tuple[s
     return cached_fasta_file, cached_metadata_jsonl_path, True
 
 
-def _monitor_subprocess_with_progress(process: subprocess.Popen[Any], cmd: list[str], timeout: int | None = None, progress_timeout: int | None = None) -> subprocess.CompletedProcess[Any]:
+def _monitor_subprocess_with_progress(
+    process: subprocess.Popen[Any], cmd: list[str], timeout: int | None = None, progress_timeout: int | None = None
+) -> subprocess.CompletedProcess[Any]:
     """Monitor a subprocess with progress tracking and timeout handling.
 
     This helper function monitors a running subprocess. When stdout/stderr are piped, it checks for progress indicators. When they're not piped (output goes to console), it simply polls for completion.
@@ -3463,7 +3474,13 @@ def download_alphainfluenza_optimized(
     )
 
 
-def download_sequences_by_accessions(accessions: list[str], outdir: str | None = None, batch_size: int = 200, failed_commands: dict[str, Any] | None = None, api_key: str | None = None) -> str:
+def download_sequences_by_accessions(
+    accessions: list[str],
+    outdir: str | None = None,
+    batch_size: int = 200,
+    failed_commands: dict[str, Any] | None = None,
+    api_key: str | None = None,
+) -> str:
     """Download virus genome sequences for a specific list of accession numbers.
 
     This function downloads sequences for a pre-filtered list of accessions,
@@ -3590,7 +3607,9 @@ def download_sequences_by_accessions(accessions: list[str], outdir: str | None =
     )
 
 
-def _download_sequences_epost_efetch(accessions: list[str], fasta_path: str, failed_commands: dict[str, Any] | None = None, api_key: str | None = None) -> str:
+def _download_sequences_epost_efetch(
+    accessions: list[str], fasta_path: str, failed_commands: dict[str, Any] | None = None, api_key: str | None = None
+) -> str:
     """Download FASTA sequences using NCBI EPost + EFetch History Server pipeline.
 
     This is NCBI's recommended approach for large datasets. It uploads accession
@@ -3756,7 +3775,11 @@ def _download_sequences_epost_efetch(accessions: list[str], fasta_path: str, fai
 
 
 def _download_sequences_single_batch(
-    accessions: list[str], NCBI_EUTILS_BASE_EFETCH: str, fasta_path: str, failed_commands: dict[str, Any] | None = None, api_key: str | None = None
+    accessions: list[str],
+    NCBI_EUTILS_BASE_EFETCH: str,
+    fasta_path: str,
+    failed_commands: dict[str, Any] | None = None,
+    api_key: str | None = None,
 ) -> str:
     """Download sequences in a single E-utilities request with exponential backoff retries.
 
@@ -3882,7 +3905,12 @@ def _download_sequences_single_batch(
 
 
 def _download_sequences_batched(
-    accessions: list[str], NCBI_EUTILS_BASE_EFETCH: str, fasta_path: str, batch_size: int, failed_commands: dict[str, Any] | None = None, api_key: str | None = None
+    accessions: list[str],
+    NCBI_EUTILS_BASE_EFETCH: str,
+    fasta_path: str,
+    batch_size: int,
+    failed_commands: dict[str, Any] | None = None,
+    api_key: str | None = None,
 ) -> str:
     """Download sequences using multiple batched E-utilities requests with incremental file writing.
 
@@ -4154,7 +4182,9 @@ def _parse_date(date_str: str, filtername: str = "") -> datetime:
         #     return None
 
 
-def _parse_partial_date_for_range_check(date_str: str, for_min_comparison: bool = True, filtername: str = "") -> datetime:
+def _parse_partial_date_for_range_check(
+    date_str: str, for_min_comparison: bool = True, filtername: str = ""
+) -> datetime:
     """Parse partial dates with range-aware handling for comparison.
 
     When comparing partial dates (year-only or year-month) against specific dates,
@@ -4749,7 +4779,9 @@ def load_metadata_from_api_reports(api_reports: list[dict[str, Any]]) -> dict[st
     return metadata_dict
 
 
-def _check_protein_requirements(record: Any, metadata: dict[str, Any], has_proteins: Any, proteins_complete: bool) -> bool:
+def _check_protein_requirements(
+    record: Any, metadata: dict[str, Any], has_proteins: Any, proteins_complete: bool
+) -> bool:
     """Check if a sequence meets protein/gene requirements based on FASTA header.
 
     This function validates whether a virus sequence contains required proteins
@@ -5491,7 +5523,9 @@ def merge_metadata_csvs(genbank_csv_path: str, standard_csv_path: str) -> bool:
         return False
 
 
-def save_metadata_to_csv(filtered_metadata: list[dict[str, Any]], protein_headers: list[Any], output_metadata_file: str) -> None:
+def save_metadata_to_csv(
+    filtered_metadata: list[dict[str, Any]], protein_headers: list[Any], output_metadata_file: str
+) -> None:
     """Save filtered metadata to a CSV file with a specific column order.
 
     This function creates a comprehensive CSV file containing all relevant metadata
@@ -5968,7 +6002,14 @@ def _epost_accessions(accessions: list[str], api_key: str | None = None) -> tupl
         return None, None
 
 
-def _efetch_with_history(web_env: str, query_key: str, retstart: int, retmax: int, api_key: str | None = None, failed_log_path: str | None = None) -> tuple[dict[str, Any], str]:
+def _efetch_with_history(
+    web_env: str,
+    query_key: str,
+    retstart: int,
+    retmax: int,
+    api_key: str | None = None,
+    failed_log_path: str | None = None,
+) -> tuple[dict[str, Any], str]:
     """Fetch GenBank records using History Server reference (WebEnv/query_key).
 
     This is the NCBI-recommended method for large datasets. After uploading UIDs
@@ -6609,7 +6650,9 @@ def fetch_genbank_metadata(
     return all_metadata, failed_log_path if os.path.exists(failed_log_path) else None
 
 
-def _fetch_genbank_batch(accessions: list[str], failed_log_path: str | None = None) -> tuple[dict[str, Any], str | None]:
+def _fetch_genbank_batch(
+    accessions: list[str], failed_log_path: str | None = None
+) -> tuple[dict[str, Any], str | None]:
     """Fetch GenBank metadata for a single batch of accessions.
 
     Includes retry logic with exponential backoff and automatic batch splitting
@@ -7188,7 +7231,9 @@ def _parse_genbank_xml(xml_content: str) -> dict[str, Any]:
     return metadata_dict
 
 
-def save_genbank_metadata_to_csv(genbank_metadata: dict[str, Any], output_file: str, virus_metadata: list[dict[str, Any]] | None = None) -> None:
+def save_genbank_metadata_to_csv(
+    genbank_metadata: dict[str, Any], output_file: str, virus_metadata: list[dict[str, Any]] | None = None
+) -> None:
     """Save GenBank metadata to a CSV file with the same column headers as the standard metadata CSV.
 
     Args:

--- a/gget/main.py
+++ b/gget/main.py
@@ -30,20 +30,18 @@ from .gget_cosmic import cosmic  # noqa: E402
 from .gget_diamond import diamond  # noqa: E402
 from .gget_elm import elm  # noqa: E402
 from .gget_enrichr import enrichr  # noqa: E402
-from .gget_g2p import g2p
+from .gget_g2p import g2p  # noqa: E402
 from .gget_gpt import gpt  # noqa: E402
 from .gget_info import info  # noqa: E402
 from .gget_muscle import muscle  # noqa: E402
 from .gget_mutate import mutate  # noqa: E402
 from .gget_opentargets import OPENTARGETS_RESOURCES, opentargets  # noqa: E402
 from .gget_pdb import pdb  # noqa: E402
-
-# Module functions
-from .gget_ref import ref
-from .gget_search import search
-from .gget_seq import seq
-from .gget_setup import setup
-from .gget_virus import virus
+from .gget_ref import ref  # noqa: E402
+from .gget_search import search  # noqa: E402
+from .gget_seq import seq  # noqa: E402
+from .gget_setup import setup  # noqa: E402
+from .gget_virus import virus  # noqa: E402
 
 
 # Custom formatter for help messages that preserved the text formatting and adds the default value to the end of the help message

--- a/gget/main.py
+++ b/gget/main.py
@@ -1382,6 +1382,7 @@ def main() -> None:
         type=str,
         choices=[
             "pdb",
+            "mmcif",
             "entry",
             "pubmed",
             "assembly",
@@ -1396,7 +1397,10 @@ def main() -> None:
         required=False,
         help=(
             "Defines type of information to be returned.\n\n"
-            '"pdb": Returns the protein structure in PDB format.\n'
+            '"pdb": Returns the protein structure in legacy PDB format. Automatically falls\n'
+            "       back to PDBx/mmCIF when the legacy PDB file is unavailable (e.g. for\n"
+            "       large structures), since the legacy PDB format is being phased out by RCSB.\n"
+            '"mmcif": Returns the protein structure in PDBx/mmCIF format (.cif).\n'
             '"entry": Information about PDB structures at the top level of PDB structure hierarchical data organization.\n'
             '"pubmed": Get PubMed annotations (data integrated from PubMed) for a given entry\'s primary citation.\n'
             '"assembly": Information about PDB structures at the quaternary structure level.\n'
@@ -1427,7 +1431,7 @@ def main() -> None:
         required=False,
         help=(
             "Path to the file the results will be saved in, e.g. path/to/directory/7S7U.pdb or path/to/directory/7S7U_entry.json.\n"
-            "Resource 'pdb' is returned in PDB format. All other resources are returned in JSON format.\n"
+            "Resource 'pdb' is returned in PDB format (or PDBx/mmCIF if the legacy PDB file is unavailable), 'mmcif' in PDBx/mmCIF format. All other resources are returned in JSON format.\n"
             "Default: Standard out."
         ),
     )
@@ -3708,7 +3712,7 @@ def main() -> None:
         )
 
         if pdb_results:
-            if args.resource == "pdb":
+            if args.resource in ("pdb", "mmcif"):
                 if args.out:
                     # Create saving directory
                     directory = "/".join(args.out.split("/")[:-1])

--- a/gget/main.py
+++ b/gget/main.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import Any
-
 import argparse
 import sys
 from datetime import datetime
+from typing import Any
 
 import pandas as pd
 
@@ -31,6 +30,7 @@ from .gget_cosmic import cosmic  # noqa: E402
 from .gget_diamond import diamond  # noqa: E402
 from .gget_elm import elm  # noqa: E402
 from .gget_enrichr import enrichr  # noqa: E402
+from .gget_g2p import g2p
 from .gget_gpt import gpt  # noqa: E402
 from .gget_info import info  # noqa: E402
 from .gget_muscle import muscle  # noqa: E402
@@ -41,27 +41,8 @@ from .gget_pdb import pdb  # noqa: E402
 # Module functions
 from .gget_ref import ref
 from .gget_search import search
-from .gget_info import info
 from .gget_seq import seq
-from .gget_muscle import muscle
-from .gget_blast import blast
-from .gget_blat import blat
-from .gget_enrichr import enrichr
-from .gget_archs4 import archs4
-from .gget_alphafold import alphafold
 from .gget_setup import setup
-from .gget_pdb import pdb
-from .gget_gpt import gpt
-from .gget_cellxgene import cellxgene
-from .gget_elm import elm
-from .gget_diamond import diamond
-from .gget_cosmic import cosmic
-from .gget_mutate import mutate
-from .gget_opentargets import opentargets, OPENTARGETS_RESOURCES
-from .gget_cbio import cbio_plot, cbio_search
-from .gget_bgee import bgee
-from .gget_g2p import g2p
-from .gget_8cube import specificity, psi_block, gene_expression
 from .gget_virus import virus
 
 
@@ -3839,16 +3820,12 @@ def main() -> None:
                 if args.csv:
                     g2p_results.to_csv(f, index=False)
                 else:
-                    g2p_results.to_json(
-                        f, orient="records", force_ascii=False, indent=4
-                    )
+                    g2p_results.to_json(f, orient="records", force_ascii=False, indent=4)
         else:
             if args.csv:
                 g2p_results.to_csv(sys.stdout, index=False)
             else:
-                print(
-                    g2p_results.to_json(orient="records", force_ascii=False, indent=4)
-                )
+                print(g2p_results.to_json(orient="records", force_ascii=False, indent=4))
 
     ## 8cube return
     if args.command == "8cube":

--- a/gget/utils.py
+++ b/gget/utils.py
@@ -7,7 +7,8 @@ import logging
 import os
 import time
 import uuid
-from typing import TYPE_CHECKING, Any, Callable, Iterable
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -1296,8 +1297,7 @@ def _shared_library_install_hint(lib_basename: str, system: str) -> str:
 
     if system == "Darwin":
         return (
-            "Install the package that provides this library via Homebrew (https://brew.sh) "
-            "or another package manager."
+            "Install the package that provides this library via Homebrew (https://brew.sh) or another package manager."
         )
     if system == "Linux":
         return "Install the package that provides this library via your system package manager."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,6 @@ lint.per-file-ignores."tests/*" = [ "D" ]
 lint.pydocstyle.convention = "numpy"
 
 [tool.mypy]
-python_version = "3.12"
 files = [ "gget" ]
 # `gget/constants.py` (module) coexists with `gget/constants/` (data dir, no
 # __init__.py). Mypy's default namespace-package discovery treats the data dir
@@ -135,11 +134,12 @@ files = [ "gget" ]
 namespace_packages = false
 ignore_missing_imports = true
 follow_imports = "silent"
-check_untyped_defs = false
-disallow_untyped_defs = false
+python_version = "3.12"
 disallow_any_generics = false
-warn_unused_ignores = true
+disallow_untyped_defs = false
+check_untyped_defs = false
 warn_redundant_casts = true
+warn_unused_ignores = true
 show_error_codes = true
 
 [tool.pytest]

--- a/tests/pytest_results.txt
+++ b/tests/pytest_results.txt
@@ -422,8 +422,8 @@ self = <tests.test_bgee.TestBgee testMethod=test_bgee_expression>
 >       result_to_test = do_call(func, td[test]["args"])
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/from_json.py:68: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/from_json.py:68:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 tests/from_json.py:60: in do_call
     return func(**args)
            ^^^^^^^^^^^^
@@ -435,7 +435,7 @@ gget/gget_bgee.py:117: in _bgee_expression
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 gget/gget_bgee.py:24: in _bgee_species
     payload = http_json(
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 
 method = 'GET', url = 'https://bgee.org/api/'
 context = 'Bgee API (species lookup)', timeout = (10, 60), retries = 3
@@ -453,10 +453,10 @@ kwargs = {'params': {'display_type': 'json', 'page': 'gene', 'action': 'general_
         **kwargs: Any,
     ) -> Any:
         """Issue an HTTP request and return the parsed JSON body, raising a
-    
+
         RuntimeError with consistent context if the request fails or the body
         is not valid JSON.
-    
+
         `context` is a short human-readable label (e.g. "Bgee API") used in
         error messages so users can identify which upstream service failed.
         Transient failures (connection errors, read timeouts, HTTP 5xx) are
@@ -505,8 +505,8 @@ self = <tests.test_bgee.TestBgee testMethod=test_bgee_expression_multiple>
 >       result_to_test = do_call(func, td[test]["args"])
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/from_json.py:68: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/from_json.py:68:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 tests/from_json.py:60: in do_call
     return func(**args)
            ^^^^^^^^^^^^
@@ -518,7 +518,7 @@ gget/gget_bgee.py:117: in _bgee_expression
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 gget/gget_bgee.py:24: in _bgee_species
     payload = http_json(
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 
 method = 'GET', url = 'https://bgee.org/api/'
 context = 'Bgee API (species lookup)', timeout = (10, 60), retries = 3
@@ -536,10 +536,10 @@ kwargs = {'params': {'display_type': 'json', 'page': 'gene', 'action': 'general_
         **kwargs: Any,
     ) -> Any:
         """Issue an HTTP request and return the parsed JSON body, raising a
-    
+
         RuntimeError with consistent context if the request fails or the body
         is not valid JSON.
-    
+
         `context` is a short human-readable label (e.g. "Bgee API") used in
         error messages so users can identify which upstream service failed.
         Transient failures (connection errors, read timeouts, HTTP 5xx) are
@@ -588,8 +588,8 @@ self = <tests.test_bgee.TestBgee testMethod=test_bgee_orthologs>
 >       result_to_test = do_call(func, td[test]["args"])
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/from_json.py:68: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/from_json.py:68:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 tests/from_json.py:60: in do_call
     return func(**args)
            ^^^^^^^^^^^^
@@ -601,7 +601,7 @@ gget/gget_bgee.py:60: in _bgee_orthologs
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 gget/gget_bgee.py:24: in _bgee_species
     payload = http_json(
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 
 method = 'GET', url = 'https://bgee.org/api/'
 context = 'Bgee API (species lookup)', timeout = (10, 60), retries = 3
@@ -619,10 +619,10 @@ kwargs = {'params': {'display_type': 'json', 'page': 'gene', 'action': 'general_
         **kwargs: Any,
     ) -> Any:
         """Issue an HTTP request and return the parsed JSON body, raising a
-    
+
         RuntimeError with consistent context if the request fails or the body
         is not valid JSON.
-    
+
         `context` is a short human-readable label (e.g. "Bgee API") used in
         error messages so users can identify which upstream service failed.
         Transient failures (connection errors, read timeouts, HTTP 5xx) are

--- a/tests/test_g2p.py
+++ b/tests/test_g2p.py
@@ -1,4 +1,5 @@
 import unittest
+
 from gget.gget_g2p import g2p
 
 

--- a/tests/test_pdb.py
+++ b/tests/test_pdb.py
@@ -78,10 +78,28 @@ class TestPDB(unittest.TestCase):
             "The reference and fetched PDB are not the same.",
         )
 
+    def test_pdb_mmcif(self):
+        # Explicit PDBx/mmCIF download returns a CIF document (starts with "data_<ID>")
+        result = pdb("4ACQ", resource="mmcif")
+        self.assertTrue(
+            result.startswith("data_4ACQ"),
+            "resource='mmcif' did not return a PDBx/mmCIF document.",
+        )
+
+    def test_pdb_legacy_fallback_to_mmcif(self):
+        # Regression test for #177/#178: 6Q38 has no legacy PDB file, so a
+        # resource='pdb' request must transparently fall back to PDBx/mmCIF.
+        result = pdb("6Q38", resource="pdb")
+        self.assertTrue(
+            result.startswith("data_6Q38"),
+            "resource='pdb' did not fall back to PDBx/mmCIF when the legacy PDB file is missing.",
+        )
+
     def tearDown(self):
         super().tearDown()
-        # Delete temporary result file
-        try:
-            os.remove("4ACQ.pdb")
-        except OSError:
-            pass
+        # Delete temporary result files
+        for fname in ("4ACQ.pdb", "4ACQ.cif", "6Q38.cif"):
+            try:
+                os.remove(fname)
+            except OSError:
+                pass


### PR DESCRIPTION
## Summary

Resolves #178 (and the user-reported failure in #177). Adds **PDBx/mmCIF** support to `gget pdb`.

The legacy PDB text format is being phased out by RCSB and is **not generated for large structures**. For such entries (e.g. `6Q38`, `7A01`) `files.rcsb.org/download/<id>.pdb` returns **404**, so the current `gget pdb` fails with `... was not found` — exactly the bug in #177 — even though the structure is available as mmCIF.

## What it does

- **New `resource="mmcif"`** downloads the structure in PDBx/mmCIF format (`<id>.cif`).
- **Automatic fallback:** the default `resource="pdb"` now tries the legacy PDB file (wwPDB → RCSB) and, only if it is unavailable, transparently falls back to PDBx/mmCIF. A `WARNING` is logged so the user knows the format changed and can switch to `-r mmcif` to silence it.
- **Correct file extensions:** saved structure files use `.cif` when mmCIF was fetched and `.pdb` otherwise (the Python `save=True` path), so file contents and names never disagree.
- **Backward compatible:** commands that already worked are unchanged; commands that previously failed on mmCIF-only entries now succeed.

```bash
gget pdb 6Q38                    # legacy missing -> auto-falls back to mmCIF (+ warning)
gget pdb 6Q38 -r mmcif -o 6Q38.cif   # explicit PDBx/mmCIF
gget pdb 7S7U                    # unchanged: legacy PDB
```

## Changes

- `gget/gget_pdb.py` — add `mmcif` resource, `(url, format)` request list with fallback, format-aware save extension, and the fallback warning.
- `gget/main.py` — add `mmcif` to the `-r/--resource` choices, update help text, and route `mmcif` through the structure-file (text) output path.
- `tests/test_pdb.py` — `test_pdb_mmcif` (explicit mmCIF) and `test_pdb_legacy_fallback_to_mmcif` (regression for `6Q38`, i.e. #177).
- `docs/src/en/pdb.md`, `docs/src/en/updates.md` — document the new option, the fallback behavior, and a usage example.

## Testing

`pytest tests/test_pdb.py` — all 4 tests pass (existing `assembly` + `pdb`, plus the 2 new ones). `ruff format` clean on the changed module/tests; pre-existing lint in untouched code left as-is to keep the diff scoped.