### PR TITLE
feat(blast): support NCBI core_nt database (#188)

### DIFF
--- a/docs/src/en/blast.md
+++ b/docs/src/en/blast.md
@@ -15,8 +15,9 @@ Nucleotide or amino acid sequence, or path to FASTA or .txt file.
 Default: 'blastn' for nucleotide sequences; 'blastp' for amino acid sequences.
 
 `-db` `--database`  
-'nt', 'nr', 'refseq_rna', 'refseq_protein', 'swissprot', 'pdbaa', or 'pdbnt'.  
+'nt', 'core_nt', 'nr', 'refseq_rna', 'refseq_protein', 'swissprot', 'pdbaa', or 'pdbnt'.  
 Default: 'nt' for nucleotide sequences; 'nr' for amino acid sequences.  
+('core_nt' is NCBI's curated "core nucleotide" collection and is now the default nucleotide database on NCBI web BLAST.)  
 [More info on BLAST databases](https://ncbi.github.io/blast-cloud/blastdb/available-blastdbs.html)
 
 `-l` `--limit`  

--- a/docs/src/en/updates.md
+++ b/docs/src/en/updates.md
@@ -8,6 +8,7 @@
 - [`gget pdb`](pdb.md): Added support for the PDBx/mmCIF structure format (fixes [issue 178](https://github.com/scverse/gget/issues/178) and [issue 177](https://github.com/scverse/gget/issues/177)).
   - New `resource="mmcif"` option downloads the structure in PDBx/mmCIF format (`.cif`).
   - The default `resource="pdb"` now automatically falls back to PDBx/mmCIF when the legacy PDB file is unavailable (e.g. for large structures), since the legacy PDB format is being phased out by RCSB. A warning is logged and saved files use the correct extension (`.cif`).
+- [`gget blast`](blast.md): Added support for NCBI's `core_nt` database (the curated "core nucleotide" collection that is now the default nucleotide database on NCBI web BLAST). `core_nt` can now be passed to `--database`/`database=` and is validated as a nucleotide database equivalently to `nt`; existing database choices (including `nt`) remain unchanged. Resolves [issue 188](https://github.com/scverse/gget/issues/188).
 
 
 **Version ≥ 0.30.7** (Jun 21, 2026):  

--- a/gget/gget_blast.py
+++ b/gget/gget_blast.py
@@ -78,7 +78,7 @@ def blast(
                       (If more than one sequence in FASTA file, only the first will be submitted to BLAST.)
      - program        'blastn', 'blastp', 'blastx', 'tblastn', or 'tblastx'.
                       Default: 'blastn' for nucleotide sequences; 'blastp' for amino acid sequences.
-     - database       'nt', 'nr', 'refseq_rna', 'refseq_protein', 'swissprot', 'pdbaa', or 'pdbnt'.
+     - database       'nt', 'core_nt', 'nr', 'refseq_rna', 'refseq_protein', 'swissprot', 'pdbaa', or 'pdbnt'.
                       Default: 'nt' for nucleotide sequences; 'nr' for amino acid sequences.
                       More info on BLAST databases: https://ncbi.github.io/blast-cloud/blastdb/available-blastdbs.html
      - limit          Limits number of hits to return. Default 50.
@@ -144,7 +144,7 @@ def blast(
     database = database.lower()
     # Valid program and database options
     programs = ["blastn", "blastp", "blastx", "tblastn", "tblastx"]
-    dbs = ["nt", "nr", "refseq_rna", "refseq_protein", "swissprot", "pdbaa", "pdbnt"]
+    dbs = ["nt", "core_nt", "nr", "refseq_rna", "refseq_protein", "swissprot", "pdbaa", "pdbnt"]
 
     # If user does not specify the program,
     # check if a nulceotide or amino acid sequence was passed

--- a/gget/main.py
+++ b/gget/main.py
@@ -828,6 +828,7 @@ def main() -> None:
         "--database",
         choices=[
             "nt",
+            "core_nt",
             "nr",
             "refseq_rna",
             "refseq_protein",
@@ -839,7 +840,7 @@ def main() -> None:
         type=str,
         required=False,
         help=(
-            "'nt', 'nr', 'refseq_rna', 'refseq_protein', 'swissprot', 'pdbaa', or 'pdbnt'. "
+            "'nt', 'core_nt', 'nr', 'refseq_rna', 'refseq_protein', 'swissprot', 'pdbaa', or 'pdbnt'. "
             "Default: 'nt' for nucleotide sequences; 'nr' for amino acid sequences. "
             "More info on BLAST databases: https://ncbi.github.io/blast-cloud/blastdb/available-blastdbs.html"
         ),

--- a/tests/fixtures/test_blast.json
+++ b/tests/fixtures/test_blast.json
@@ -70,5 +70,8 @@
             "database": "banana"
         },
         "expected_result": "ValueError"
+    },
+    "test_blast_core_nt_accepted": {
+        "type": "code_defined"
     }
 }

--- a/tests/test_blast.py
+++ b/tests/test_blast.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+from unittest import mock
 
 from gget.gget_blast import blast
 
@@ -11,4 +12,22 @@ with open("./tests/fixtures/test_blast.json") as json_file:
 
 
 class TestBlast(unittest.TestCase, metaclass=from_json(blast_dict, blast)):
-    pass  # all tests are loaded from json
+    def test_blast_core_nt_accepted(self):
+        # 'core_nt' must pass argument validation (i.e. must not raise the
+        # "invalid database" ValueError) and be submitted to NCBI as a
+        # nucleotide database, equivalently to 'nt'. The network call is
+        # mocked so no live BLAST job is submitted (those take minutes).
+        # NOTE: This does not exercise an end-to-end BLAST against core_nt;
+        # that should be verified manually.
+        sequence = "ATGCGTACGTAGCTAGCTAGCTAGCATCGATCGATCGTAGCTAGCTAGC"
+
+        with mock.patch("gget.gget_blast.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = RuntimeError("network call reached")
+            # Validation passes -> we reach the (mocked) network call, which
+            # raises our sentinel. If validation rejected 'core_nt', a
+            # ValueError would be raised before urlopen is ever called.
+            with self.assertRaises(RuntimeError) as cm:
+                blast(sequence, database="core_nt", verbose=False)
+
+        self.assertEqual(str(cm.exception), "network call reached")
+        self.assertTrue(mock_urlopen.called)


### PR DESCRIPTION
## Summary

Resolves #188. Adds **`core_nt`** as a selectable BLAST database for `gget blast`.

NCBI web BLAST has switched its **default nucleotide database to `core_nt`** — a curated "core nucleotide" collection that is replacing/renaming the legacy `nt` database. `gget blast` validates `--database` against a fixed allow-list that did not include `core_nt`, so users could not target the database NCBI now uses by default.

## What it does

- Adds `core_nt` to the accepted database list, both in the Python API (`gget.blast(..., database="core_nt")`) and the CLI (`gget blast ... -db core_nt`).
- `core_nt` is treated as a nucleotide database, identical to `nt` (default program `blastn`); no special-casing needed.
- Fully backward compatible — `nt` and all existing database choices are unchanged.

```bash
gget blast --database core_nt MKVLLAA...   # or -db core_nt
```

## Changes

- `gget/gget_blast.py` — add `core_nt` to the `dbs` validation list and the `database` docstring.
- `gget/main.py` — add `core_nt` to the `--database` argparse `choices` and help text.
- `tests/test_blast.py` + `tests/fixtures/test_blast.json` — `test_blast_core_nt_accepted`: asserts `database="core_nt"` passes validation and reaches the network call (mocked) instead of raising the "invalid database" error.
- `docs/src/en/blast.md`, `docs/src/en/updates.md` — document the new option (issue 188).

## Testing

`pytest tests/test_blast.py -k core_nt` passes. `ruff check` clean on the changed files. The new test deliberately mocks the network layer and does **not** submit a live BLAST job (those take minutes); a live end-to-end `blastn` against `core_nt` was not run in CI and can be spot-checked manually.