### PR TITLE
fix(opentargets): give drug synonyms/tradeNames a GraphQL sub-selection (HTTP 400 fix)

### DIFF
--- a/docs/src/en/updates.md
+++ b/docs/src/en/updates.md
@@ -8,6 +8,7 @@
 - [`gget pdb`](pdb.md): Added support for the PDBx/mmCIF structure format (fixes [issue 178](https://github.com/scverse/gget/issues/178) and [issue 177](https://github.com/scverse/gget/issues/177)).
   - New `resource="mmcif"` option downloads the structure in PDBx/mmCIF format (`.cif`).
   - The default `resource="pdb"` now automatically falls back to PDBx/mmCIF when the legacy PDB file is unavailable (e.g. for large structures), since the legacy PDB format is being phased out by RCSB. A warning is logged and saved files use the correct extension (`.cif`).
+- [`gget opentargets`](opentargets.md): Fixed `resource="drugs"` returning an HTTP 400 error after OpenTargets changed the `synonyms` and `tradeNames` fields from `[String!]!` to the object type `[DrugLabelAndSource!]!`. The GraphQL query now requests a sub-selection (`{ label }`) and the response is flattened back to a list of strings, keeping the output backward-compatible.
 
 
 **Version ≥ 0.30.7** (Jun 21, 2026):  

--- a/gget/gget_opentargets.py
+++ b/gget/gget_opentargets.py
@@ -43,8 +43,12 @@ query target($ensemblId: String!) {
             }
           }
           description
-          synonyms
-          tradeNames
+          synonyms {
+            label
+          }
+          tradeNames {
+            label
+          }
           maximumClinicalStage
           indications {
             rows {
@@ -384,6 +388,20 @@ def opentargets(
         if verbose:
             logger.info(f"No {resource} data found for {ensembl_id}.")
         return pd.DataFrame() if not json else []
+
+    if resource == "drugs":
+        # OpenTargets changed 'synonyms'/'tradeNames' from [String!]! to
+        # [DrugLabelAndSource!]!, which requires a sub-selection (see query above).
+        # Flatten each object back to its 'label' string to keep the output
+        # backward-compatible (a list of strings).
+        for row in rows:
+            drug = row.get("drug")
+            if not isinstance(drug, dict):
+                continue
+            for field in ("synonyms", "tradeNames"):
+                values = drug.get(field)
+                if isinstance(values, list):
+                    drug[field] = [v["label"] for v in values if isinstance(v, dict) and "label" in v]
 
     # ---------------------------
     # If JSON → return normalized JSON


### PR DESCRIPTION
## Summary

OpenTargets changed the `Drug` `synonyms` and `tradeNames` fields from `[String!]!` to the object type `[DrugLabelAndSource!]!`. Because our GraphQL drug query selected these as bare scalars, OpenTargets now rejects the query and **every `gget opentargets … -r drugs` call returns HTTP 400**. This also breaks CI on `dev` and on every open PR (the suite runs the live drug query), so it masks unrelated red.

## What it does

- The drug query now requests a sub-selection — `synonyms { label }` and `tradeNames { label }` — for both fields (introspection confirms `DrugLabelAndSource` exposes `label` and `source`, both `String!`).
- The response is flattened back to a list of `label` strings before normalization, so the DataFrame/JSON output is **backward compatible** (still a list of strings, not objects).

## Testing

- **Live API**: the corrected query now returns **HTTP 200** with sensible synonyms (e.g. `LEBRIKIZUMAB → ['Lebrikizumab', 'Lebrikizumab-lbkz', 'MILR-1444A']`).
- `tests/test_opentargets.py::test_error_opentargets_drugs_invalid_filter` **passes**.
- The remaining `test_opentargets_drugs` failure is **unrelated OpenTargets data drift** in `drug.indications.rows` (e.g. `EFO_0000274` vs `MONDO_0004980`, both "atopic eczema") — out of scope for this HTTP 400 fix.

Refs #243