### PR TITLE
fix(archs4): tolerate missing color column from ARCHS4 (no crash)

### DIFF
--- a/gget/gget_archs4.py
+++ b/gget/gget_archs4.py
@@ -200,8 +200,10 @@ def archs4(
         # Drop NaN rows
         tissue_exp_df = tissue_exp_df.dropna()
 
-        # Drop color columns
-        tissue_exp_df = tissue_exp_df.drop(["color"], axis=1)
+        # Drop the "color" column if present (only used for plotting upstream, not by gget).
+        # ARCHS4 intermittently omits this column; use errors="ignore" so a missing
+        # "color" column does not raise a KeyError and crash the request.
+        tissue_exp_df = tissue_exp_df.drop(columns=["color"], errors="ignore")
 
         # Sort data frame by median expression
         tissue_exp_df = tissue_exp_df.sort_values("median", ascending=False)

--- a/tests/test_archs4.py
+++ b/tests/test_archs4.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+from unittest.mock import patch
 
 from gget.gget_archs4 import archs4
 
@@ -12,3 +13,33 @@ with open("./tests/fixtures/test_archs4.json") as json_file:
 
 class TestArchs4(unittest.TestCase, metaclass=from_json(archs4_dict, archs4)):
     pass  # all tests are loaded from json
+
+
+class _FakeResponse:
+    def __init__(self, text, ok=True):
+        self.ok = ok
+        self.content = text.encode("utf-8")
+
+
+class TestArchs4MissingColor(unittest.TestCase):
+    """Network-free regression tests: ARCHS4 intermittently omits the 'color' column
+    from the tissue-expression CSV. gget must not crash with a KeyError in that case
+    (the 'color' column is dropped and never used)."""
+
+    _CSV_WITH_COLOR = "id,min,q1,median,q3,max,color\nTissueA,0,1,5,9,10,#fff\nTissueB,0,2,8,12,15,#000\n"
+    _CSV_NO_COLOR = "id,min,q1,median,q3,max\nTissueA,0,1,5,9,10\nTissueB,0,2,8,12,15\n"
+
+    def test_tissue_missing_color_does_not_crash(self):
+        with patch("gget.gget_archs4.requests.post", return_value=_FakeResponse(self._CSV_NO_COLOR)):
+            df = archs4("STAT4", which="tissue", verbose=False)
+        # Returns a valid, sorted data frame without a 'color' column (no KeyError)
+        self.assertEqual(len(df), 2)
+        self.assertNotIn("color", df.columns)
+        self.assertEqual(df.iloc[0]["id"], "TissueB")  # sorted by median descending
+
+    def test_tissue_with_color_still_dropped(self):
+        with patch("gget.gget_archs4.requests.post", return_value=_FakeResponse(self._CSV_WITH_COLOR)):
+            df = archs4("STAT4", which="tissue", verbose=False)
+        self.assertEqual(len(df), 2)
+        self.assertNotIn("color", df.columns)
+        self.assertEqual(df.iloc[0]["id"], "TissueB")


### PR DESCRIPTION
## Summary

ARCHS4's tissue-expression CSV intermittently omits the `color` column. `gget archs4 --which tissue` did `tissue_exp_df.drop(["color"], axis=1)`, which raises `KeyError: "['color'] not found in axis"` when the column is absent — so the request crashed for users. This is a real upstream-drift breakage (the column comes and goes from the ARCHS4 response), not a test-only issue.

## What it does

`gget/gget_archs4.py`: change the drop to `tissue_exp_df.drop(columns=["color"], errors="ignore")`. The `color` column is only used for plotting upstream and is never used downstream by gget, so it is dropped when present and ignored when absent — no crash either way. Behaviour is unchanged when `color` is present.

## Testing

- 2 network-free regression tests (`TestArchs4MissingColor`, mocking `requests.post`): a CSV **without** `color` and one **with** `color` both return a valid, median-sorted data frame with no `color` column and no `KeyError`.
- Live ARCHS4 still works (today's response includes `color`; it is dropped as before).

Refs #243
