### PR TITLE
test(opentargets): loosen live-data assertions to structural/invariant (data drifts across releases)

### DIFF
--- a/tests/fixtures/test_opentargets.json
+++ b/tests/fixtures/test_opentargets.json
@@ -1,25 +1,11 @@
 {
   "test_opentargets": {
-    "type": "assert_equal",
+    "type": "code_defined",
     "args": {
       "ensembl_id": "ENSG00000169194",
       "resource": "diseases",
       "limit": 2
-    },
-    "expected_result": [
-      [
-        0.7297489019498119,
-        "EFO_0000274",
-        "atopic eczema",
-        "A common chronic pruritic inflammatory skin disease with a strong genetic component. Onset typically occurs during the first 2 years of life."
-      ],
-      [
-        0.6642728577751653,
-        "MONDO_0004979",
-        "asthma",
-        "A bronchial disease that is characterized by chronic inflammation and narrowing of the airways, which is caused by a combination of environmental and genetic factors resulting in recurring periods of wheezing (a whistling sound while breathing), chest tightness, shortness of breath, mucus production and coughing. The symptoms appear due to a variety of triggers such as allergens, irritants, respiratory infections, weather changes, exercise, stress, reflux disease, medications, foods and emotional anxiety."
-      ]
-    ]
+    }
   },
   "test_opentargets_expression_no_limit": {
     "type": "assert_equal_json_hash",
@@ -30,15 +16,14 @@
     "expected_result": "7d32780ec48250553246c816d80b93ee"
   },
   "test_opentargets_depmap": {
-    "type": "assert_equal_json_hash",
+    "type": "code_defined",
     "args": {
       "ensembl_id": "ENSG00000169194",
       "resource": "depmap"
-    },
-    "expected_result": "c335cc9c9b3167e8c5b3084e339c88a7"
+    }
   },
   "test_opentargets_depmap_filter": {
-    "type": "assert_equal",
+    "type": "code_defined",
     "args": {
       "ensembl_id": "ENSG00000169194",
       "resource": "depmap",
@@ -46,35 +31,14 @@
         "tissueId": "UBERON_0002367"
       },
       "limit": 2
-    },
-    "expected_result": [
-      [
-        "UBERON_0002367",
-        "prostate gland",
-        "DU 145",
-        0.034343916922807693,
-        "Prostate Adenocarcinoma",
-        "ACH-000979",
-        -0.14336788654327393
-      ],
-      [
-        "UBERON_0002367",
-        "prostate gland",
-        "WPE1-NA22",
-        0.0291899424046278,
-        "Non-Cancerous",
-        "ACH-001422",
-        0.06934770196676254
-      ]
-    ]
+    }
   },
   "test_opentargets_interactions_no_limit": {
-    "type": "assert_equal_json_hash",
+    "type": "code_defined",
     "args": {
       "ensembl_id": "ENSG00000169194",
       "resource": "interactions"
-    },
-    "expected_result": "fa95d278c2d31ded3731e154d65fcda5"
+    }
   },
   "test_opentargets_interactions_simple_filter": {
     "type": "assert_equal",
@@ -154,27 +118,12 @@
     "expected_result": "ValueError"
   },
   "test_opentargets_diseases": {
-    "function_call_to_reproduce": "output = opentargets(ensembl_id='ENSG00000169194', resource='diseases', limit=2, json=True, verbose=False); print(json.dumps(output, indent=2))",
-    "type": "assert_equal_json_with_keys",
+    "type": "code_defined",
     "args": {
       "ensembl_id": "ENSG00000169194",
       "resource": "diseases",
       "limit": 2
-    },
-    "expected_result": [
-      {
-        "score": 0.7297489019,
-        "disease.id": "EFO_0000274",
-        "disease.name": "atopic eczema",
-        "disease.description": "A common chronic pruritic inflammatory skin disease with a strong genetic component. Onset typically occurs during the first 2 years of life."
-      },
-      {
-        "score": 0.6642728578,
-        "disease.id": "MONDO_0004979",
-        "disease.name": "asthma",
-        "disease.description": "A bronchial disease that is characterized by chronic inflammation and narrowing of the airways, which is caused by a combination of environmental and genetic factors resulting in recurring periods of wheezing (a whistling sound while breathing), chest tightness, shortness of breath, mucus production and coughing. The symptoms appear due to a variety of triggers such as allergens, irritants, respiratory infections, weather changes, exercise, stress, reflux disease, medications, foods and emotional anxiety."
-      }
-    ]
+    }
   },
   "test_opentargets_drugs": {
     "function_call_to_reproduce": "output = opentargets(ensembl_id='ENSG00000169194', resource='drugs', limit=2, json=True, verbose=False); print(json.dumps(output, indent=2))",
@@ -300,89 +249,20 @@
     ]
   },
   "test_opentargets_interactions": {
-    "function_call_to_reproduce": "output = opentargets(ensembl_id='ENSG00000169194', resource='interactions', limit=2, json=True, verbose=False); print(json.dumps(output, indent=2))",
-    "type": "assert_equal_json_with_keys",
+    "type": "code_defined",
     "args": {
       "ensembl_id": "ENSG00000169194",
       "resource": "interactions",
       "limit": 2
-    },
-    "expected_result": [
-      {
-        "score": 0.999,
-        "count": 3,
-        "sourceDatabase": "string",
-        "intA": "ENSP00000304915",
-        "intABiologicalRole": "unspecified role",
-        "intB": "ENSP00000361004",
-        "intBBiologicalRole": "unspecified role",
-        "targetA.id": "ENSG00000169194",
-        "targetA.approvedSymbol": "IL13",
-        "speciesA.taxonId": 134,
-        "targetB.id": "ENSG00000123496",
-        "targetB.approvedSymbol": "IL13RA2",
-        "speciesB.taxonId": 134
-      },
-      {
-        "score": 0.999,
-        "count": 3,
-        "sourceDatabase": "string",
-        "intA": "ENSP00000304915",
-        "intABiologicalRole": "unspecified role",
-        "intB": "ENSP00000360730",
-        "intBBiologicalRole": "unspecified role",
-        "targetA.id": "ENSG00000169194",
-        "targetA.approvedSymbol": "IL13",
-        "speciesA.taxonId": 134,
-        "targetB.id": "ENSG00000131724",
-        "targetB.approvedSymbol": "IL13RA1",
-        "speciesB.taxonId": 134
-      }
-    ]
+    }
   },
   "test_opentargets_pharmacogenetics": {
-    "function_call_to_reproduce": "output = opentargets(ensembl_id='ENSG00000169194', resource='pharmacogenetics', limit=2, json=True, verbose=False); print(json.dumps(output, indent=2))",
-    "type": "assert_equal_json_with_keys",
+    "type": "code_defined",
     "args": {
       "ensembl_id": "ENSG00000169194",
       "resource": "pharmacogenetics",
       "limit": 2
-    },
-    "expected_result": [
-      {
-        "variantId": "5_132657117_C_T",
-        "genotypeId": "5_132657117_C_C,T",
-        "genotype": "CT",
-        "drugs": {
-          "id": "CHEMBL535",
-          "name": "SUNITINIB"
-        },
-        "phenotypeText": "decreased severity of drug-induced toxicity",
-        "genotypeAnnotationText": "Patients with renal cell carcinoma and the CT genotype may have a decreased severity of drug-induced toxicity when administered sunitinib as compared to patients with the TT genotype. Other clinical and genetic factors may also influence severity of drug-induced toxicity in patients with renal cell carcinoma who are administered sunitinib.",
-        "pgxCategory": "toxicity",
-        "isDirectTarget": false,
-        "evidenceLevel": "3",
-        "datasourceId": "clinpgx",
-        "literature": "26387812",
-        "variantFunctionalConsequence.id": "SO:0001631",
-        "variantFunctionalConsequence.label": "upstream_gene_variant"
-      },
-      {
-        "variantId": "5_132660151_T_C",
-        "genotypeId": "5_132660151_T_C,C",
-        "genotype": "CC",
-        "drugs": null,
-        "phenotypeText": "decreased risk for non-immune response",
-        "genotypeAnnotationText": "Patients with the CC genotype may be at decreased risk for non-immune response to the hepatitis B vaccine, as compared to patients with the TT genotype. Other genetic and clinical factors may also influence risk of non-immune response in patients receiving the hepatitis B vaccine.",
-        "pgxCategory": "efficacy",
-        "isDirectTarget": false,
-        "evidenceLevel": "3",
-        "datasourceId": "clinpgx",
-        "literature": "21111021",
-        "variantFunctionalConsequence.id": "SO:0001627",
-        "variantFunctionalConsequence.label": "intron_variant"
-      }
-    ]
+    }
   },
   "test_opentargets_tractability": {
     "function_call_to_reproduce": "output = opentargets(ensembl_id='ENSG00000169194', resource='tractability', limit=2, json=True, verbose=False); print(json.dumps(output, indent=2))",

--- a/tests/test_opentargets.py
+++ b/tests/test_opentargets.py
@@ -1,6 +1,8 @@
 import json
+import re
 import unittest
 
+import pandas as pd
 from gget.gget_opentargets import opentargets
 
 from .from_json import from_json
@@ -9,6 +11,103 @@ from .from_json import from_json
 with open("./tests/fixtures/test_opentargets.json") as json_file:
     ot_dict = json.load(json_file)
 
+# Invariant value-format patterns: loose enough to survive routine OpenTargets data
+# drift across releases, strict enough to catch genuine shape/format regressions.
+_CURIE = re.compile(r"^[A-Za-z][A-Za-z0-9]*[_:][A-Za-z0-9]+$")  # e.g. MONDO_0004980, EFO_0000274, UBERON_0000977
+_ENSG = re.compile(r"^ENSG\d+$")
+_ACH = re.compile(r"^ACH-\d+$")  # DepMap cell-line id, e.g. ACH-000092
+_GENOTYPE = re.compile(r"^[ACGTN/,\- ]+$", re.IGNORECASE)  # nucleotide-allele genotypes, e.g. CT, CC, TT
+
 
 class TestOpenTargets(unittest.TestCase, metaclass=from_json(ot_dict, opentargets)):
-    pass  # all tests are loaded from json
+    """Most tests are generated from the JSON fixture. The methods below override the
+    fixture entries marked ``code_defined`` for resources whose live data legitimately
+    drifts between OpenTargets releases (disease ids/scores, DepMap rows, interaction
+    partners, pharmacogenetics genotypes).
+
+    They assert structure and value *format* / invariants rather than pinning exact
+    values, so they keep catching real regressions (wrong columns, malformed ids,
+    empty-where-guaranteed, broken filtering) without breaking on routine upstream
+    data updates. See issue #249."""
+
+    def _run(self, name, **overrides):
+        """Call opentargets with the fixture args for ``name`` (quietly)."""
+        args = {**ot_dict[name]["args"], "verbose": False, **overrides}
+        return opentargets(**args)
+
+    # ----- diseases: top disease id + score drift each release -----
+    def _assert_diseases(self, df):
+        self.assertGreater(len(df), 0, "diseases query returned no rows")
+        for col in ("score", "disease.id", "disease.name"):
+            self.assertIn(col, df.columns)
+        self.assertTrue(pd.api.types.is_numeric_dtype(df["score"]))
+        for s in df["score"].dropna().head(50):
+            self.assertGreaterEqual(float(s), 0.0)
+            self.assertLessEqual(float(s), 1.0)
+        for disease_id in df["disease.id"].dropna().head(50):
+            self.assertRegex(str(disease_id), _CURIE)
+        for disease_name in df["disease.name"].dropna().head(50):
+            self.assertTrue(str(disease_name).strip(), "empty disease name")
+
+    def test_opentargets(self):
+        self._assert_diseases(self._run("test_opentargets"))
+
+    def test_opentargets_diseases(self):
+        self._assert_diseases(self._run("test_opentargets_diseases"))
+
+    # ----- depmap: gene-effect rows change between releases -----
+    def test_opentargets_depmap(self):
+        df = self._run("test_opentargets_depmap")
+        self.assertGreater(len(df), 0, "depmap query returned no rows")
+        for col in ("tissueId", "tissueName", "depmapId", "geneEffect"):
+            self.assertIn(col, df.columns)
+        self.assertTrue(pd.api.types.is_numeric_dtype(df["geneEffect"]))
+        for tissue_id in df["tissueId"].dropna().head(50):
+            self.assertRegex(str(tissue_id), _CURIE)
+        for depmap_id in df["depmapId"].dropna().head(50):
+            self.assertRegex(str(depmap_id), _ACH)
+
+    def test_opentargets_depmap_filter(self):
+        # The filter invariant must hold regardless of which tissues currently carry
+        # data: pick a tissue that is present now, then assert filtering returns only
+        # rows for that tissue. (Pinning a specific tissue id is fragile — a given
+        # tissue's screens can be empty in some releases.)
+        eid = ot_dict["test_opentargets_depmap_filter"]["args"]["ensembl_id"]
+        full = opentargets(ensembl_id=eid, resource="depmap", verbose=False)
+        self.assertIn("tissueId", full.columns)
+        self.assertGreater(len(full), 0, "depmap query returned no rows to filter")
+        tissue = full.iloc[0]["tissueId"]
+        filtered = opentargets(ensembl_id=eid, resource="depmap", filters={"tissueId": tissue}, verbose=False)
+        self.assertGreater(len(filtered), 0)
+        self.assertTrue((filtered["tissueId"] == tissue).all(), "filter returned rows for other tissues")
+
+    # ----- interactions: partner ids change between releases -----
+    def _assert_interactions(self, df):
+        self.assertGreater(len(df), 0, "interactions query returned no rows")
+        for col in ("score", "targetA.id", "targetB.id"):
+            self.assertIn(col, df.columns)
+        self.assertTrue(pd.api.types.is_numeric_dtype(df["score"]))
+        for s in df["score"].dropna().head(50):
+            self.assertGreaterEqual(float(s), 0.0)
+            self.assertLessEqual(float(s), 1.0)
+        for gene_id in df["targetA.id"].dropna().head(50):
+            self.assertRegex(str(gene_id), _ENSG)
+        for gene_id in df["targetB.id"].dropna().head(50):
+            self.assertRegex(str(gene_id), _ENSG)
+
+    def test_opentargets_interactions(self):
+        self._assert_interactions(self._run("test_opentargets_interactions"))
+
+    def test_opentargets_interactions_no_limit(self):
+        self._assert_interactions(self._run("test_opentargets_interactions_no_limit"))
+
+    # ----- pharmacogenetics: surfaced genotype / row order drift -----
+    def test_opentargets_pharmacogenetics(self):
+        df = self._run("test_opentargets_pharmacogenetics")
+        self.assertGreater(len(df), 0, "pharmacogenetics query returned no rows")
+        for col in ("variantId", "genotype", "genotypeId"):
+            self.assertIn(col, df.columns)
+        for genotype in df["genotype"].dropna().head(50):
+            self.assertRegex(str(genotype), _GENOTYPE)
+        for variant_id in df["variantId"].dropna().head(50):
+            self.assertTrue(str(variant_id).strip(), "empty variantId")


### PR DESCRIPTION
## Summary

OpenTargets is a live database that is re-released regularly. Several `gget opentargets` tests pinned the **exact current values** returned by the live API (disease ids/scores, md5 result hashes, interaction-partner Ensembl ids, genotypes), so they broke every time OpenTargets shipped a new data release — even on PRs that never touch the opentargets module. gget itself returns correct, current data; only the pinned expectations were stale.

This replaces the exact-value/hash assertions for those tests with **structural and invariant** assertions that still catch real regressions but survive routine upstream data drift. The fixture entries are marked `code_defined`; the structural test methods live in `tests/test_opentargets.py` (they override the fixture-generated exact-match versions).

## What invariant replaces which exact value

- **`test_opentargets`, `test_opentargets_diseases`** — was: exact top disease id + score (`EFO_0000274` / `0.7297`). Now: non-empty; columns `score`, `disease.id`, `disease.name` present; `score` numeric and within the closed interval zero to one; `disease.id` matches an ontology-curie pattern (`^[A-Za-z][A-Za-z0-9]*[_:][A-Za-z0-9]+$`, e.g. `MONDO_...`, `EFO_...`, `HP_...`); disease names non-empty.
- **`test_opentargets_depmap`** — was: md5 hash of the whole result. Now: non-empty; columns `tissueId`, `tissueName`, `depmapId`, `geneEffect` present; `geneEffect` numeric; `tissueId` matches the ontology-curie pattern; `depmapId` matches `^ACH-\d+$`.
- **`test_opentargets_depmap_filter`** — was: exact filtered rows for one hard-coded tissue (which can be empty in some releases). Now: pick a tissue that currently carries data, then assert the **filter invariant** — the filtered result is non-empty and every returned row has that `tissueId`.
- **`test_opentargets_interactions`, `test_opentargets_interactions_no_limit`** — was: a specific partner Ensembl id + md5 hash. Now: non-empty; columns `score`, `targetA.id`, `targetB.id` present; `score` numeric in zero-to-one; `targetA.id` / `targetB.id` match `^ENSG\d+$`.
- **`test_opentargets_pharmacogenetics`** — was: a specific genotype (`CC`). Now: non-empty; columns `variantId`, `genotype`, `genotypeId` present; `genotype` matches a nucleotide-allele pattern (`^[ACGTN/,\- ]+$`, e.g. `CT`, `CC`, `TT`); `variantId` non-empty.

These remain meaningful: they fail if gget returns the wrong columns, malformed ids, non-numeric scores, empty results where data is guaranteed, or broken filtering.

## Testing

All seven loosened tests pass against current live OpenTargets data (7 passed in ~4.3s). Because they assert structure and value *format* rather than exact values, they are robust to future release drift (the exact values used by the previous assertions had already changed upstream: top disease `EFO_0000274` → `MONDO_0004980`, pharmacogenetics genotype `CC` → `CT`, etc.). Per-row format checks sample the first 50 rows to stay fast on large results.

Scope note: this PR is only the value-drift tests. The deterministic breakages are handled separately — the `synonyms` HTTP 400 in PR #244, and the `expression` field retirement in issue #247 / PR #248.

Resolves #249

CI context: #243
