### PR TITLE
fix(types): allow tuple request timeouts in http_json

### DIFF
--- a/gget/utils.py
+++ b/gget/utils.py
@@ -103,7 +103,7 @@ def http_json(
     url: str,
     *,
     context: str = "",
-    timeout: float = DEFAULT_REQUESTS_TIMEOUT,
+    timeout: float | tuple[float, float] = DEFAULT_REQUESTS_TIMEOUT,
     retries: int = 3,
     backoff: float = 1.0,
     **kwargs: Any,


### PR DESCRIPTION
## Summary
- Allow `http_json(timeout=...)` to accept requests-style `(connect_timeout, read_timeout)` tuples.
- Match the existing `DEFAULT_REQUESTS_TIMEOUT = (10, 60)` value used by `http_json` callers.

## Validation
- Ran `pre-commit run mypy --files gget/utils.py gget/gget_opentargets.py`.
- Confirmed the previous timeout-related mypy errors are gone.
- Remaining mypy failures are pre-existing errors in `gget/utils.py`.