### PR TITLE
docs(archs4): clarify legacy endpoint vs archs4.org data source (#254)

### DIFF
--- a/docs/src/en/archs4.md
+++ b/docs/src/en/archs4.md
@@ -5,6 +5,8 @@
 Find the most correlated genes to a gene of interest or find the gene's tissue expression atlas using [ARCHS4](https://maayanlab.cloud/archs4/).  
 Return format: JSON (command-line) or data frame/CSV (Python).
 
+> **Note on the data source:** `gget archs4` queries the legacy ARCHS4 HTTP endpoints at `maayanlab.cloud`, which are lightweight and still maintained. ARCHS4 has since launched a new site ([archs4.org](https://archs4.org)) with a larger, more up-to-date dataset, but its programmatic access is provided only via the [`archs4py`](https://github.com/MaayanLab/archs4py) package and multi-GB HDF5 downloads — there is no equivalent lightweight HTTP API to query. `gget archs4` therefore continues to use the legacy endpoints. If you need the newest data or larger sample sizes, use `archs4py` directly. A possible future migration is tracked in [issue 254](https://github.com/scverse/gget/issues/254).
+
 **Positional argument**  
 `gene`  
 Short name (gene symbol) of gene of interest, e.g. STAT4.  

--- a/docs/src/en/archs4.md
+++ b/docs/src/en/archs4.md
@@ -5,7 +5,7 @@
 Find the most correlated genes to a gene of interest or find the gene's tissue expression atlas using [ARCHS4](https://maayanlab.cloud/archs4/).  
 Return format: JSON (command-line) or data frame/CSV (Python).
 
-> **Note on the data source:** `gget archs4` queries the legacy ARCHS4 HTTP endpoints at `maayanlab.cloud`, which are lightweight and still maintained. ARCHS4 has since launched a new site ([archs4.org](https://archs4.org)) with a larger, more up-to-date dataset, but its programmatic access is provided only via the [`archs4py`](https://github.com/MaayanLab/archs4py) package and multi-GB HDF5 downloads — there is no equivalent lightweight HTTP API to query. `gget archs4` therefore continues to use the legacy endpoints. If you need the newest data or larger sample sizes, use `archs4py` directly. A possible future migration is tracked in [issue 254](https://github.com/scverse/gget/issues/254).
+> **Note on the data source:** `gget archs4` queries the legacy ARCHS4 HTTP endpoints at `maayanlab.cloud`, which are lightweight and still maintained. ARCHS4 has since launched a new site ([archs4.org](https://archs4.org)) with a larger, more up-to-date dataset, but its programmatic access is provided only via the [`archs4py`](https://github.com/MaayanLab/archs4py) package and multi-GB HDF5 downloads (there is currently no equivalent lightweight HTTP API to query). `gget archs4` therefore continues to use the legacy endpoints. A possible future migration is tracked in [issue 254](https://github.com/scverse/gget/issues/254).
 
 **Positional argument**  
 `gene`  

--- a/docs/src/en/updates.md
+++ b/docs/src/en/updates.md
@@ -23,6 +23,7 @@
   - **Docs**: Clarified the meaning of the `diseases` resource `score` column (OpenTargets' single overall target–disease association score, 0–1, aggregated across all data types/sources — not a per-data-source score) and that `disease.id` values are EFO-mapped traits that include not only MONDO diseases but also phenotypes (`HP_*`) and measurements (`EFO_*`), with an example of how to filter to MONDO disease terms only. Addresses [issue 168](https://github.com/scverse/gget/issues/168).
 - [`gget archs4`](archs4.md) (tissue mode): No longer crashes with `KeyError: ['color'] not found in axis` when ARCHS4 intermittently omits the optional `color` column from its CSV response. The column is now dropped only if present. Output also has a deterministic row order (sorted by `median` descending, with `id` as tiebreaker) so equal-median tissues no longer flip order between requests.
 - [`gget bgee`](bgee.md): Outbound Bgee API requests now send a `User-Agent: gget/<version>` header so the Bgee service can attribute (and, if needed, allow-list) gget traffic, improving resilience against intermittent request blocking.
+- [`gget archs4`](archs4.md) (docs): Added a note clarifying that `gget archs4` uses the legacy `maayanlab.cloud` ARCHS4 endpoints (lightweight HTTP), while the newer [archs4.org](https://archs4.org) dataset is only accessible via `archs4py`/HDF5 downloads. A possible future migration is tracked in [issue 254](https://github.com/scverse/gget/issues/254).
 
 
 **Version ≥ 0.30.7** (Jun 21, 2026):  

--- a/docs/src/en/updates.md
+++ b/docs/src/en/updates.md
@@ -23,7 +23,6 @@
   - **Docs**: Clarified the meaning of the `diseases` resource `score` column (OpenTargets' single overall target–disease association score, 0–1, aggregated across all data types/sources — not a per-data-source score) and that `disease.id` values are EFO-mapped traits that include not only MONDO diseases but also phenotypes (`HP_*`) and measurements (`EFO_*`), with an example of how to filter to MONDO disease terms only. Addresses [issue 168](https://github.com/scverse/gget/issues/168).
 - [`gget archs4`](archs4.md) (tissue mode): No longer crashes with `KeyError: ['color'] not found in axis` when ARCHS4 intermittently omits the optional `color` column from its CSV response. The column is now dropped only if present. Output also has a deterministic row order (sorted by `median` descending, with `id` as tiebreaker) so equal-median tissues no longer flip order between requests.
 - [`gget bgee`](bgee.md): Outbound Bgee API requests now send a `User-Agent: gget/<version>` header so the Bgee service can attribute (and, if needed, allow-list) gget traffic, improving resilience against intermittent request blocking.
-- [`gget archs4`](archs4.md) (docs): Added a note clarifying that `gget archs4` uses the legacy `maayanlab.cloud` ARCHS4 endpoints (lightweight HTTP), while the newer [archs4.org](https://archs4.org) dataset is only accessible via `archs4py`/HDF5 downloads. A possible future migration is tracked in [issue 254](https://github.com/scverse/gget/issues/254).
 
 
 **Version ≥ 0.30.7** (Jun 21, 2026):  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,12 +143,6 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 show_error_codes = true
 
-# mypy-baseline grandfathers the pre-existing type errors so the pre-commit
-# mypy hook only fails on NEW errors. Refresh after fixing some with:
-#   mypy gget | mypy-baseline sync
-[tool.mypy-baseline]
-baseline_path = ".mypy-baseline.txt"
-
 [tool.pytest]
 ini_options.testpaths = [ "tests" ]
 ini_options.addopts = [ "-ra" ]
@@ -159,3 +153,9 @@ run.omit = [
   "gget/main.py",
 ]
 run.source = [ "gget" ]
+
+# mypy-baseline grandfathers the pre-existing type errors so the pre-commit
+# mypy hook only fails on NEW errors. Refresh after fixing some with:
+#   mypy gget | mypy-baseline sync
+[tool.mypy-baseline]
+baseline_path = ".mypy-baseline.txt"


### PR DESCRIPTION
Addresses #254.

## Context

#254 asks about migrating `gget archs4` off the legacy `maayanlab.cloud` ARCHS4 endpoints now that ARCHS4 has moved to [archs4.org](https://archs4.org). I investigated the feasibility:

- The **legacy endpoints still work** (verified live) and are lightweight HTTP — the right fit for gget's quick single-gene queries.
- **archs4.org has no equivalent lightweight HTTP API** (POSTs to the old paths return `405`). Its programmatic access is **only** via [`archs4py`](https://github.com/MaayanLab/archs4py) + multi-GB HDF5 downloads.

A full migration would replace an instant query with a tens-of-GB download + heavy dependency — a major UX regression that contradicts gget's design. So rather than migrate, this PR **documents the situation** so users understand the data source and their options.

## Changes (docs-only, no code)

- `docs/src/en/archs4.md`: added a note explaining that `gget archs4` uses the legacy `maayanlab.cloud` endpoints, that archs4.org's newer/larger dataset is only reachable via `archs4py`/HDF5, and that users who need the newest data should use `archs4py` directly. Links the tracking issue.
- `docs/src/en/updates.md`: brief 0.30.8 entry.

## Note on the issue

This **addresses** but does not fully close #254 — the "evaluate migration" tracker should stay open in case archs4.org later exposes a lightweight API. I used "Addresses" (not "Resolves") so it won't auto-close.