### PR TITLE
test(ci): parallelize the test suite with pytest-xdist [WIP]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ test = [
   "parameterized==0.9",
   "pytest>=7",
   "pytest-cov>=6.2.1",
+  "pytest-xdist>=3",
   "types-beautifulsoup4==4.12.0.20250516",
   "types-requests==2.33.0.20260518",
   "types-tqdm==4.68.0.20260608",
@@ -85,7 +86,7 @@ envs.hatch-test.overrides.matrix.python.features = [
 ]
 # pyproject.toml is the single source of truth for the environments CI tests:
 # the workflow reads this matrix via `hatch env show --json`.
-envs.hatch-test.default-args = [ "tests" ]
+envs.hatch-test.default-args = [ "-n", "auto", "tests" ]
 envs.hatch-test.dependency-groups = [ "test" ]
 
 [tool.ruff]

--- a/tests/test_virus.py
+++ b/tests/test_virus.py
@@ -261,24 +261,11 @@ class TestVirus(unittest.TestCase, metaclass=from_json(virus_dict, virus)):
     See module docstring for detailed parameter coverage analysis.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """Set up test fixtures that are shared across all tests."""
-        cls.test_output_dir = "test_virus_output"
-
-    @classmethod
-    def tearDownClass(cls):
-        """Clean up after all tests have run."""
-        # Clean up test output directory if it exists
-        if os.path.exists(cls.test_output_dir):
-            shutil.rmtree(cls.test_output_dir)
-
     def setUp(self):
         """Set up before each test method."""
-        # Create a fresh test output directory
-        if os.path.exists(self.test_output_dir):
-            shutil.rmtree(self.test_output_dir)
-        os.makedirs(self.test_output_dir, exist_ok=True)
+        # Create a unique per-test output directory so tests can run in parallel
+        # (pytest-xdist) without racing on a shared, fixed directory.
+        self.test_output_dir = tempfile.mkdtemp(prefix="test_virus_")
 
     def tearDown(self):
         """Clean up after each test method."""


### PR DESCRIPTION
**⚠️ WIP / draft — opened to measure the real CI speedup on the runners, not for merge yet.**

## Motivation
CI runs **~29 min per Python version** (py3.12/3.13/3.14), dominated by network-bound live tests. From a local `--durations` run, `test_virus` alone is **~64%** of the runtime: each `test_virus_with_*_filter` downloads a broad NCBI taxon (`"Zika virus"`, thousands of genomes) server-side-filtered, so every test re-fetches a large package (75–195 s each). These tests are **I/O-bound** (waiting on NCBI/Ensembl), so running them concurrently should cut wall-clock a lot **without changing what is tested**.

## Change
- Add `pytest-xdist` to the test dependency group; run hatch-test with `-n auto`.
- Isolate the `test_virus` output directory **per test** (`tempfile.mkdtemp`) instead of a single shared `"test_virus_output"` dir — the shared dir (rmtree + recreate in `setUp`) would race across parallel workers. This is the only fixed shared output dir in the suite.

All tests remain **live** — no mocking, no semantic change; only the output-dir isolation and the parallel runner.

## Local check
4 virus filter tests run concurrently (`-n 4`) pass with no races; ~70–90 s serial → 31 s parallel.

## Open questions (why WIP)
- Real speedup on GH runners (this PR's CI run is the measurement).
- Whether unauthenticated parallel requests trip NCBI/Ensembl rate limits — may need to lower `-n` or add an `NCBI_API_KEY` secret (the `virus` module already supports `api_key`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)