### PR TITLE
fix(tests): make cellxgene repr_dict robust to a spurious None layer key (#265)

### DIFF
--- a/tests/test_cellxgene.py
+++ b/tests/test_cellxgene.py
@@ -34,7 +34,11 @@ def repr_dict(adata):
         if isinstance(got_attr, int):
             d[attr] = got_attr
         else:
-            keys = list(got_attr.keys())
+            # Ignore None keys: some cellxgene-census versions return an AnnData
+            # whose `.layers` exposes a spurious `None` key, which is not a
+            # meaningful (named) element and would otherwise break the structural
+            # comparison in test_cellxgene_adata (issue #265).
+            keys = [k for k in got_attr.keys() if k is not None]
             if keys:
                 d[attr] = keys
     return d
@@ -96,3 +100,33 @@ class TestCellxgeneValidation(unittest.TestCase):
     def test_typo_species_raises_valueerror(self):
         with self.assertRaises(ValueError):
             cellxgene(species="macaca_mulata", tissue="blood")
+
+
+class TestReprDict(unittest.TestCase):
+    """Network-free tests for the repr_dict helper (issue #265).
+
+    These do not need cellxgene-census, so they run on every Python version
+    (including ones where the live Census tests are skipped), guarding the
+    None-key handling that keeps test_cellxgene_adata robust to upstream drift.
+    """
+
+    class _FakeAnnData:
+        n_obs = 3
+        n_vars = 2
+        obs = {"cell_type": None, "tissue": None}
+        var = {"feature_id": None}
+        uns: dict = {}
+        obsm: dict = {}
+        varm: dict = {}
+        layers = {None: "spurious"}  # cellxgene-census can expose a None-keyed layer
+        obsp: dict = {}
+        varp: dict = {}
+
+    def test_repr_dict_ignores_none_layer_key(self):
+        d = repr_dict(self._FakeAnnData())
+        # A layer whose only key is None must not surface as structure.
+        self.assertNotIn("layers", d)
+        # Meaningful (named) elements are still reported.
+        self.assertEqual(d["n_obs"], 3)
+        self.assertEqual(d["obs"], ["cell_type", "tissue"])
+        self.assertEqual(d["var"], ["feature_id"])


### PR DESCRIPTION
Resolves #265

## Summary

`tests/test_cellxgene.py::TestCellxgene::test_cellxgene_adata` started failing on py3.12/3.13 (it is skipped on py3.14, where `cellxgene-census` has no wheel) due to upstream drift, not any change in gget: `cellxgene-census`'s `get_anndata()` now returns an AnnData whose `.layers` exposes a spurious `None` key. The test's `repr_dict()` helper turned that into `"layers": [None]`, which no longer matched the stored expected structure.

## Fix

`repr_dict()` now ignores `None` keys when summarising an AnnData's structure, so the comparison stays on meaningful (named) elements and is robust to this drift. The `test_cellxgene_adata` fixture is left unchanged (no need to hard-code the spurious `[None]`). This is a **test-only** change — no `gget/` code is touched.

## Testing

**Unit tests** (offline, no `cellxgene-census` needed):
- new `TestReprDict::test_repr_dict_ignores_none_layer_key` — a fake AnnData with a `None`-keyed layer must not surface `layers`, while named `obs`/`var` elements still do. Runs on every Python version, so it guards the fix even where the live Census tests are skipped.

**Live tests** (`test_cellxgene_adata` etc.):
- unchanged; they exercise the real Census on py3.12/3.13 and should pass again now that `repr_dict` ignores the `None` layer. I could not run them locally (local env is py3.14 without `cellxgene-census`), so CI on this PR is the confirmation.
